### PR TITLE
Remove usage of deprecated rustfmt_bindings

### DIFF
--- a/aws-lc-fips-sys/builder/bindgen.rs
+++ b/aws-lc-fips-sys/builder/bindgen.rs
@@ -113,7 +113,7 @@ fn prepare_bindings_builder(manifest_dir: &Path, options: BindingOptions<'_>) ->
         .size_t_is_usize(true)
         .layout_tests(true)
         .prepend_enum_name(true)
-        .rustfmt_bindings(true)
+        .formatter(bindgen::Formatter::Rustfmt)
         .clang_args(clang_args)
         .raw_line(COPYRIGHT)
         .header(

--- a/aws-lc-sys/builder/bindgen.rs
+++ b/aws-lc-sys/builder/bindgen.rs
@@ -113,7 +113,7 @@ fn prepare_bindings_builder(manifest_dir: &Path, options: BindingOptions<'_>) ->
         .size_t_is_usize(true)
         .layout_tests(true)
         .prepend_enum_name(true)
-        .rustfmt_bindings(true)
+        .formatter(bindgen::Formatter::Rustfmt)
         .clang_args(clang_args)
         .raw_line(COPYRIGHT)
         .header(


### PR DESCRIPTION
Fixes #104 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
