### PR TITLE
Regenerate aws-lc-fips-sys@0.7.1

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
-version = "0.7.0"
+version = "0.7.1"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/awslabs/aws-lc"

--- a/aws-lc-fips-sys/src/linux_aarch64_crypto.rs
+++ b/aws-lc-fips-sys/src/linux_aarch64_crypto.rs
@@ -4539,38 +4539,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4579,18 +4579,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4599,18 +4599,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4619,7 +4619,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4627,11 +4627,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4642,30 +4642,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4704,30 +4704,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4737,15 +4737,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4809,7 +4809,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4817,7 +4817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4825,15 +4825,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4845,7 +4845,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4854,7 +4854,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4865,7 +4865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4876,7 +4876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4888,7 +4888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4898,7 +4898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4908,7 +4908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4919,7 +4919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5140,27 +5140,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5168,29 +5168,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5198,7 +5198,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5330,27 +5330,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5358,11 +5358,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5370,22 +5370,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5394,7 +5394,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5403,35 +5403,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5441,7 +5441,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5501,7 +5501,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5607,11 +5607,11 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5624,7 +5624,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5638,7 +5638,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5649,29 +5649,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5727,7 +5727,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5738,7 +5738,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5751,7 +5751,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5763,7 +5763,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5772,7 +5772,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5783,7 +5783,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5810,23 +5810,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5834,7 +5834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5842,7 +5842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5850,7 +5850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5858,15 +5858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5875,7 +5875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5883,7 +5883,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5892,67 +5892,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5978,7 +5978,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5986,68 +5986,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6055,7 +6055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6063,7 +6063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6072,11 +6072,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6085,15 +6085,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6101,11 +6101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6113,22 +6113,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6136,30 +6136,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6167,89 +6167,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6258,34 +6258,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6294,13 +6294,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6309,13 +6309,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6328,7 +6328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6341,7 +6341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6354,7 +6354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6366,7 +6366,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6380,7 +6380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6393,7 +6393,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6406,7 +6406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6418,46 +6418,46 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6469,7 +6469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6828,193 +6828,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7023,15 +7023,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7041,11 +7041,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7053,47 +7053,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7101,11 +7101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7113,43 +7113,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7158,7 +7158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7168,7 +7168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7177,7 +7177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7187,7 +7187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7196,7 +7196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7206,7 +7206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7215,7 +7215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7225,7 +7225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7234,7 +7234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7243,7 +7243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7251,7 +7251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7260,7 +7260,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7269,7 +7269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7278,11 +7278,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7290,7 +7290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7350,15 +7350,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7372,7 +7372,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7380,11 +7380,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7399,7 +7399,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7409,7 +7409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7420,7 +7420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7430,7 +7430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7439,7 +7439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7448,7 +7448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7457,7 +7457,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7467,7 +7467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7477,23 +7477,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7502,7 +7502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7511,7 +7511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7521,7 +7521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7530,7 +7530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7540,7 +7540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7551,7 +7551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7562,15 +7562,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7581,7 +7581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7594,11 +7594,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7606,7 +7606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7614,7 +7614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7762,15 +7762,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7794,15 +7794,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7811,7 +7811,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7819,14 +7819,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7834,7 +7834,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7842,7 +7842,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7850,7 +7850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7858,14 +7858,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7873,7 +7873,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7881,22 +7881,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7972,54 +7972,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8027,7 +8027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8035,79 +8035,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8115,7 +8115,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8123,7 +8123,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8131,7 +8131,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8139,7 +8139,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8147,7 +8147,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8155,7 +8155,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8163,7 +8163,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8171,7 +8171,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8179,117 +8179,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8297,14 +8297,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8314,7 +8314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8326,7 +8326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8336,7 +8336,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8346,15 +8346,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8362,26 +8362,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8389,23 +8389,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8413,14 +8413,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8428,25 +8428,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8454,7 +8454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8462,14 +8462,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8498,19 +8498,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8518,11 +8518,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8530,54 +8530,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8585,59 +8585,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8645,23 +8645,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8670,26 +8670,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8697,29 +8697,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8728,22 +8728,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8751,15 +8751,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8768,11 +8768,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8781,41 +8781,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8823,11 +8823,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8852,7 +8852,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8862,11 +8862,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8874,11 +8874,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8886,7 +8886,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9220,15 +9220,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9236,19 +9236,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9256,7 +9256,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9264,12 +9264,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9277,14 +9277,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9292,33 +9292,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9326,7 +9326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9334,19 +9334,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9354,7 +9354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9362,7 +9362,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9372,7 +9372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9382,11 +9382,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9394,33 +9394,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9428,34 +9428,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10065,7 +10065,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10090,19 +10090,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10112,19 +10112,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10134,7 +10134,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10142,11 +10142,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10156,7 +10156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10164,7 +10164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10374,11 +10374,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10386,11 +10386,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10445,19 +10445,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10466,7 +10466,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10527,23 +10527,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10551,82 +10551,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10634,7 +10634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10642,11 +10642,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10654,7 +10654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10663,7 +10663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10674,22 +10674,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10698,7 +10698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10707,7 +10707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10716,7 +10716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10725,33 +10725,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10759,7 +10759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10767,7 +10767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11074,23 +11074,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11098,40 +11098,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11139,15 +11139,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11155,55 +11155,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11211,11 +11211,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11223,7 +11223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11231,11 +11231,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11243,11 +11243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11258,114 +11258,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11376,7 +11376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11386,7 +11386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11396,7 +11396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11406,7 +11406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11414,7 +11414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11424,7 +11424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11432,7 +11432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11442,7 +11442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11450,47 +11450,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11499,45 +11499,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11550,23 +11550,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11576,7 +11576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11585,7 +11585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11594,7 +11594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11602,7 +11602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11610,7 +11610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11618,7 +11618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11627,110 +11627,110 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11967,7 +11967,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11977,19 +11977,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -11999,15 +11999,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12102,15 +12102,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12118,7 +12118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12126,14 +12126,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12141,7 +12141,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12149,23 +12149,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12173,15 +12173,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12268,11 +12268,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12280,19 +12280,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12300,19 +12300,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12410,11 +12410,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12422,19 +12422,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12442,15 +12442,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12548,11 +12548,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12560,34 +12560,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12595,34 +12595,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12630,7 +12630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12639,7 +12639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12648,21 +12648,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12670,7 +12670,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12678,7 +12678,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12686,7 +12686,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12695,7 +12695,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12703,11 +12703,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12734,51 +12734,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12788,70 +12788,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12859,15 +12859,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12876,7 +12876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12885,7 +12885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12896,7 +12896,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12906,11 +12906,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12921,7 +12921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -12994,15 +12994,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13011,7 +13011,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13022,7 +13022,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13033,7 +13033,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13046,7 +13046,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13058,7 +13058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13067,7 +13067,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13076,43 +13076,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13120,7 +13120,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13128,7 +13128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13137,7 +13137,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13146,40 +13146,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13188,11 +13188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13200,7 +13200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13211,19 +13211,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13231,19 +13231,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13258,7 +13258,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13266,14 +13266,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13281,114 +13281,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13396,11 +13396,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13408,7 +13408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13416,7 +13416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13424,7 +13424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13435,75 +13435,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13511,19 +13511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13615,15 +13615,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13631,11 +13631,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13643,15 +13643,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13697,43 +13697,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13741,7 +13741,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13750,7 +13750,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13758,7 +13758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13767,7 +13767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13779,11 +13779,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13837,28 +13837,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13867,7 +13867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13877,7 +13877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13888,7 +13888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13899,7 +13899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13910,47 +13910,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13960,7 +13960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13968,14 +13968,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -13983,11 +13983,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13995,11 +13995,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14007,11 +14007,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14019,7 +14019,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14175,19 +14175,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14195,19 +14195,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14215,7 +14215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14225,53 +14225,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14279,7 +14279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14288,7 +14288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14298,7 +14298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14308,7 +14308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14318,7 +14318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14328,7 +14328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14339,7 +14339,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14349,7 +14349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14359,7 +14359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14369,7 +14369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14379,7 +14379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14388,7 +14388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14396,7 +14396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14407,7 +14407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14416,7 +14416,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14425,7 +14425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14433,11 +14433,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14447,15 +14447,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14509,92 +14509,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14602,7 +14602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14611,15 +14611,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14627,11 +14627,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14639,22 +14639,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14664,7 +14664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14672,7 +14672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14794,11 +14794,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14806,11 +14806,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14818,11 +14818,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14830,14 +14830,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14854,7 +14854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14863,7 +14863,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14874,7 +14874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14885,7 +14885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14939,23 +14939,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14963,7 +14963,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -14971,7 +14971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -14979,7 +14979,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14988,19 +14988,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15008,11 +15008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15022,7 +15022,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15030,83 +15030,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15233,11 +15233,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15246,11 +15246,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15261,11 +15261,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15280,7 +15280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15295,7 +15295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15313,7 +15313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15328,66 +15328,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15398,7 +15398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15406,7 +15406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15415,7 +15415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15423,102 +15423,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15526,40 +15526,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15568,7 +15568,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15577,7 +15577,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15585,7 +15585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15593,7 +15593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15603,7 +15603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15611,7 +15611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15619,7 +15619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15629,7 +15629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15639,7 +15639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15647,7 +15647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15655,7 +15655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15665,7 +15665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15673,11 +15673,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15685,7 +15685,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15694,7 +15694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15702,11 +15702,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15714,7 +15714,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15723,7 +15723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15732,7 +15732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15741,7 +15741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15750,7 +15750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15763,7 +15763,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15775,7 +15775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15790,31 +15790,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15824,11 +15824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15838,11 +15838,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15852,11 +15852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15866,11 +15866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15880,18 +15880,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15899,18 +15899,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15920,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15930,102 +15930,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16033,28 +16033,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16062,7 +16062,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16070,7 +16070,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16080,31 +16080,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16118,7 +16118,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16132,15 +16132,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16149,7 +16149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16157,7 +16157,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16166,22 +16166,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16189,40 +16189,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16230,11 +16230,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16242,11 +16242,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16254,11 +16254,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16266,14 +16266,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16447,7 +16447,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16461,7 +16461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16473,7 +16473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16485,11 +16485,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16497,15 +16497,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16592,7 +16592,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16604,27 +16604,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16634,7 +16634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16642,7 +16642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16650,23 +16650,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16675,7 +16675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16851,82 +16851,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16935,18 +16935,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16955,7 +16955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16964,23 +16964,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16996,7 +16996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17014,7 +17014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17027,7 +17027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17040,7 +17040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17053,7 +17053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17063,19 +17063,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17334,7 +17334,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17342,7 +17342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17351,7 +17351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17360,22 +17360,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17383,15 +17383,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17478,66 +17478,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17546,7 +17546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17554,7 +17554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17562,7 +17562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17643,7 +17643,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17662,7 +17662,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17670,47 +17670,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18004,51 +18004,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18074,15 +18074,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18090,18 +18090,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18109,79 +18109,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18190,11 +18190,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18203,7 +18203,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18212,12 +18212,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18226,7 +18226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18235,7 +18235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18243,7 +18243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18255,7 +18255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18267,7 +18267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18277,7 +18277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18287,7 +18287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18298,7 +18298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18312,7 +18312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18324,7 +18324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18335,7 +18335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18348,7 +18348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18360,7 +18360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18370,7 +18370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18380,31 +18380,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18415,7 +18415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18426,7 +18426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18439,7 +18439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18450,19 +18450,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18470,19 +18470,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18490,7 +18490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18500,7 +18500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18508,26 +18508,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18536,7 +18536,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18544,11 +18544,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18556,11 +18556,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18570,7 +18570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18580,7 +18580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18591,7 +18591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18599,7 +18599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19100,27 +19100,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19128,51 +19128,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19185,15 +19185,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19201,7 +19201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19209,7 +19209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19217,15 +19217,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19233,68 +19233,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19302,7 +19302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19310,25 +19310,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19336,14 +19336,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19351,7 +19351,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19359,7 +19359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19367,14 +19367,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19396,23 +19396,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19420,23 +19420,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19445,19 +19445,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19465,7 +19465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19473,7 +19473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19481,11 +19481,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19493,55 +19493,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19549,7 +19549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19557,25 +19557,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19583,19 +19583,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19603,23 +19603,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19627,33 +19627,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19661,22 +19661,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19726,19 +19726,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19746,15 +19746,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19762,15 +19762,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19778,7 +19778,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19786,21 +19786,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19809,7 +19809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19821,7 +19821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19833,7 +19833,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19845,19 +19845,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19865,33 +19865,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19900,11 +19900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19914,7 +19914,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19924,7 +19924,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19934,19 +19934,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19954,18 +19954,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19974,7 +19974,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19983,33 +19983,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20033,11 +20033,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20045,18 +20045,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20064,7 +20064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20072,7 +20072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20080,21 +20080,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20123,23 +20123,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20147,11 +20147,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20160,7 +20160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20169,15 +20169,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20185,7 +20185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20193,7 +20193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20202,7 +20202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20211,7 +20211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20220,7 +20220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20229,7 +20229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20238,259 +20238,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20498,11 +20498,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20512,7 +20512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20520,14 +20520,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20537,7 +20537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20545,42 +20545,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20589,7 +20589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21162,11 +21162,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21174,7 +21174,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21182,54 +21182,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21237,23 +21237,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21261,7 +21261,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21270,44 +21270,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21315,34 +21315,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21350,26 +21350,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21377,18 +21377,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21396,38 +21396,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21435,25 +21435,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21461,7 +21461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21469,23 +21469,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21493,26 +21493,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21520,26 +21520,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21547,7 +21547,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21557,7 +21557,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21567,7 +21567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21577,7 +21577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21589,7 +21589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21600,15 +21600,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21616,18 +21616,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21635,7 +21635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21643,28 +21643,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21674,7 +21674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21684,7 +21684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21694,37 +21694,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21734,66 +21734,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21802,19 +21802,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21823,7 +21823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21831,7 +21831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21840,7 +21840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21849,15 +21849,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21866,11 +21866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21879,7 +21879,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21889,7 +21889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21898,7 +21898,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21908,11 +21908,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21920,7 +21920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21928,7 +21928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21936,21 +21936,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21958,7 +21958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21967,7 +21967,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21977,11 +21977,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21989,7 +21989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21997,28 +21997,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22028,7 +22028,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22038,7 +22038,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22048,7 +22048,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22058,7 +22058,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22068,7 +22068,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22078,14 +22078,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22094,7 +22094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22103,34 +22103,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22138,26 +22138,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22168,7 +22168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22178,11 +22178,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22190,19 +22190,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22219,19 +22219,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22318,15 +22318,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22334,14 +22334,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22460,18 +22460,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22479,7 +22479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22487,202 +22487,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22690,15 +22690,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22707,50 +22707,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22759,7 +22759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22769,7 +22769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22777,7 +22777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22785,7 +22785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22793,19 +22793,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22814,11 +22814,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22826,81 +22826,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22909,11 +22909,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22921,7 +22921,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22933,105 +22933,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23039,7 +23039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23047,20 +23047,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23068,7 +23068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23076,42 +23076,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23123,14 +23123,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23140,7 +23140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23150,7 +23150,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23160,7 +23160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23172,7 +23172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23183,7 +23183,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23197,7 +23197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23206,7 +23206,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23216,7 +23216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23226,7 +23226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23237,7 +23237,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23251,7 +23251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23260,7 +23260,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23269,11 +23269,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23282,7 +23282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23291,7 +23291,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23300,15 +23300,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23317,7 +23317,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23326,15 +23326,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23343,7 +23343,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23352,23 +23352,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23377,7 +23377,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23386,15 +23386,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23403,7 +23403,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23412,15 +23412,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23429,7 +23429,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23438,15 +23438,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23455,7 +23455,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23464,21 +23464,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23487,7 +23487,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23496,7 +23496,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23508,7 +23508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23520,7 +23520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23529,7 +23529,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23538,15 +23538,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23555,7 +23555,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23564,15 +23564,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23581,7 +23581,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23590,7 +23590,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23602,7 +23602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23614,7 +23614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23623,7 +23623,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23632,15 +23632,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23649,7 +23649,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23658,15 +23658,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23675,7 +23675,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23684,7 +23684,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23696,7 +23696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23708,7 +23708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23717,7 +23717,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23726,15 +23726,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23743,7 +23743,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23752,15 +23752,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23769,7 +23769,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23778,7 +23778,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23790,7 +23790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23802,7 +23802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23811,7 +23811,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23820,15 +23820,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23840,7 +23840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23852,7 +23852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23864,7 +23864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23876,7 +23876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23885,7 +23885,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23897,7 +23897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23909,7 +23909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23921,7 +23921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23930,7 +23930,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23942,7 +23942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23955,7 +23955,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -23969,7 +23969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -23977,7 +23977,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -23985,7 +23985,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -23994,11 +23994,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24006,27 +24006,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24036,7 +24036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24044,7 +24044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24059,74 +24059,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24227,19 +24227,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24304,11 +24304,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24395,11 +24395,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24407,27 +24407,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24502,15 +24502,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24523,7 +24523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24538,18 +24538,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24558,14 +24558,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24574,7 +24574,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24585,7 +24585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24594,7 +24594,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24606,7 +24606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24618,18 +24618,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24637,14 +24637,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24652,7 +24652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24666,7 +24666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24681,7 +24681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24694,7 +24694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24709,7 +24709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26417,15 +26417,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26433,26 +26433,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26460,14 +26460,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26699,15 +26699,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26715,26 +26715,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26742,26 +26742,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26769,29 +26769,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26799,19 +26799,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26819,18 +26819,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26838,7 +26838,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26846,15 +26846,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26862,26 +26862,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26889,22 +26889,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26912,14 +26912,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26927,7 +26927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26935,14 +26935,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26950,15 +26950,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26966,33 +26966,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27000,26 +27000,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27027,26 +27027,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27054,26 +27054,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27081,26 +27081,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27108,26 +27108,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27135,26 +27135,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27162,26 +27162,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27189,26 +27189,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27216,38 +27216,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27255,26 +27255,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27282,70 +27282,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27356,7 +27356,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27364,7 +27364,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27374,7 +27374,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27472,7 +27472,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27483,11 +27483,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27496,7 +27496,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27505,7 +27505,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27514,7 +27514,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27523,7 +27523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27532,7 +27532,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27541,7 +27541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27550,67 +27550,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27619,14 +27619,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27634,7 +27634,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27644,7 +27644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27653,7 +27653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27662,7 +27662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27671,7 +27671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27681,11 +27681,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27693,70 +27693,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27774,43 +27774,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27820,7 +27820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27829,7 +27829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27838,7 +27838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27846,11 +27846,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/linux_aarch64_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/linux_aarch64_crypto_ssl.rs
@@ -5539,38 +5539,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5579,18 +5579,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5599,18 +5599,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5619,7 +5619,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5627,11 +5627,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5642,30 +5642,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5704,30 +5704,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5737,15 +5737,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5809,7 +5809,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5817,7 +5817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5825,15 +5825,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5845,7 +5845,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5854,7 +5854,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5865,7 +5865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5876,7 +5876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5888,7 +5888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5898,7 +5898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5908,7 +5908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5919,7 +5919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -6140,27 +6140,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -6168,29 +6168,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6198,7 +6198,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6330,27 +6330,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6358,11 +6358,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6370,22 +6370,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6394,7 +6394,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6403,35 +6403,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6441,7 +6441,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6501,7 +6501,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6607,11 +6607,11 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6624,7 +6624,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6638,7 +6638,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6649,29 +6649,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6727,7 +6727,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6738,7 +6738,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6751,7 +6751,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6763,7 +6763,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6772,7 +6772,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6783,7 +6783,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6810,23 +6810,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6834,7 +6834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6842,7 +6842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6850,7 +6850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6858,15 +6858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6875,7 +6875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6883,7 +6883,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6892,67 +6892,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6978,7 +6978,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6986,68 +6986,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7055,7 +7055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7063,7 +7063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7072,11 +7072,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7085,15 +7085,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7101,11 +7101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7113,22 +7113,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7136,30 +7136,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7167,89 +7167,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7258,34 +7258,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7294,13 +7294,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7309,13 +7309,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7328,7 +7328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7341,7 +7341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7354,7 +7354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7366,7 +7366,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7380,7 +7380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7393,7 +7393,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7406,7 +7406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7418,46 +7418,46 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7469,7 +7469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7828,193 +7828,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8023,15 +8023,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8041,11 +8041,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8053,47 +8053,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8101,11 +8101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8113,43 +8113,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8158,7 +8158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8168,7 +8168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8177,7 +8177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8187,7 +8187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8196,7 +8196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8206,7 +8206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8215,7 +8215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8225,7 +8225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8234,7 +8234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8243,7 +8243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8251,7 +8251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8260,7 +8260,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8269,7 +8269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8278,11 +8278,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8290,7 +8290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8350,15 +8350,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8372,7 +8372,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8380,11 +8380,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8399,7 +8399,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8409,7 +8409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8420,7 +8420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8430,7 +8430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8439,7 +8439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8448,7 +8448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8457,7 +8457,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8467,7 +8467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8477,23 +8477,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8502,7 +8502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8511,7 +8511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8521,7 +8521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8530,7 +8530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8540,7 +8540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8551,7 +8551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8562,15 +8562,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8581,7 +8581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8594,11 +8594,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8606,7 +8606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8614,7 +8614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8762,15 +8762,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8794,15 +8794,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8811,7 +8811,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8819,14 +8819,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8834,7 +8834,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8842,7 +8842,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8850,7 +8850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8858,14 +8858,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8873,7 +8873,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8881,22 +8881,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8972,54 +8972,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9027,7 +9027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9035,79 +9035,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9115,7 +9115,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9123,7 +9123,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9131,7 +9131,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9139,7 +9139,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9147,7 +9147,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9155,7 +9155,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9163,7 +9163,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9171,7 +9171,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9179,117 +9179,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9297,14 +9297,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9314,7 +9314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9326,7 +9326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9336,7 +9336,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9346,15 +9346,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9362,26 +9362,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9389,23 +9389,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9413,14 +9413,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9428,25 +9428,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9454,7 +9454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9462,14 +9462,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9498,19 +9498,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9518,11 +9518,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9530,54 +9530,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9585,59 +9585,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9645,23 +9645,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9670,26 +9670,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9697,29 +9697,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9728,22 +9728,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9751,15 +9751,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9768,11 +9768,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9781,41 +9781,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9823,11 +9823,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9852,7 +9852,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9862,11 +9862,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9874,11 +9874,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9886,7 +9886,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10220,15 +10220,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10236,19 +10236,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10256,7 +10256,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10264,12 +10264,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10277,14 +10277,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10292,33 +10292,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10326,7 +10326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10334,19 +10334,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10354,7 +10354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10362,7 +10362,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10372,7 +10372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10382,11 +10382,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10394,33 +10394,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10428,34 +10428,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11065,7 +11065,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11090,19 +11090,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11112,19 +11112,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11134,7 +11134,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11142,11 +11142,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11156,7 +11156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11164,7 +11164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11374,11 +11374,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11386,11 +11386,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11445,19 +11445,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11466,7 +11466,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11527,23 +11527,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11551,82 +11551,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11634,7 +11634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11642,11 +11642,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11654,7 +11654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11663,7 +11663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11674,22 +11674,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11698,7 +11698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11707,7 +11707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11716,7 +11716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11725,33 +11725,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11759,7 +11759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11767,7 +11767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12074,23 +12074,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12098,40 +12098,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12139,15 +12139,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12155,55 +12155,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12211,11 +12211,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12223,7 +12223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12231,11 +12231,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12243,11 +12243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12258,114 +12258,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12376,7 +12376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12386,7 +12386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12396,7 +12396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12406,7 +12406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12414,7 +12414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12424,7 +12424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12432,7 +12432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12442,7 +12442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12450,47 +12450,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12499,45 +12499,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12550,23 +12550,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12576,7 +12576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12585,7 +12585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12594,7 +12594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12602,7 +12602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12610,7 +12610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12618,7 +12618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12627,110 +12627,110 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12967,7 +12967,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12977,19 +12977,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12999,15 +12999,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13102,15 +13102,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13118,7 +13118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13126,14 +13126,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13141,7 +13141,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13149,23 +13149,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13173,15 +13173,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13268,11 +13268,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13280,19 +13280,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13300,19 +13300,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13410,11 +13410,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13422,19 +13422,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13442,15 +13442,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13548,11 +13548,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13560,34 +13560,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13595,34 +13595,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13630,7 +13630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13639,7 +13639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13648,21 +13648,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13670,7 +13670,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13678,7 +13678,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13686,7 +13686,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13695,7 +13695,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13703,11 +13703,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13734,51 +13734,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13788,70 +13788,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13859,15 +13859,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13876,7 +13876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13885,7 +13885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13896,7 +13896,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13906,11 +13906,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13921,7 +13921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13994,15 +13994,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14011,7 +14011,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14022,7 +14022,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14033,7 +14033,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14046,7 +14046,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14058,7 +14058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14067,7 +14067,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14076,43 +14076,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14120,7 +14120,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14128,7 +14128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14137,7 +14137,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14146,40 +14146,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14188,11 +14188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14200,7 +14200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14211,19 +14211,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14231,19 +14231,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14258,7 +14258,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14266,14 +14266,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14281,114 +14281,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14396,11 +14396,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14408,7 +14408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14416,7 +14416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14424,7 +14424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14435,75 +14435,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14511,19 +14511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14615,15 +14615,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14631,11 +14631,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14643,15 +14643,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14697,43 +14697,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14741,7 +14741,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14750,7 +14750,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14758,7 +14758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14767,7 +14767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14779,11 +14779,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14837,28 +14837,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14867,7 +14867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14877,7 +14877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14888,7 +14888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14899,7 +14899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14910,47 +14910,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14960,7 +14960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14968,14 +14968,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14983,11 +14983,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14995,11 +14995,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15007,11 +15007,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15019,7 +15019,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15175,19 +15175,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15195,19 +15195,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15215,7 +15215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15225,53 +15225,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15279,7 +15279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15288,7 +15288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15298,7 +15298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15308,7 +15308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15318,7 +15318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15328,7 +15328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15339,7 +15339,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15349,7 +15349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15359,7 +15359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15369,7 +15369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15379,7 +15379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15388,7 +15388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15396,7 +15396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15407,7 +15407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15416,7 +15416,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15425,7 +15425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15433,11 +15433,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15447,15 +15447,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15509,92 +15509,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15602,7 +15602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15611,15 +15611,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15627,11 +15627,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15639,22 +15639,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15664,7 +15664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15672,7 +15672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15794,11 +15794,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15806,11 +15806,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15818,11 +15818,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15830,14 +15830,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15854,7 +15854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15863,7 +15863,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15874,7 +15874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15885,7 +15885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15939,23 +15939,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15963,7 +15963,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15971,7 +15971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15979,7 +15979,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15988,19 +15988,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16008,11 +16008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16022,7 +16022,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16030,83 +16030,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16233,11 +16233,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16246,11 +16246,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16261,11 +16261,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16280,7 +16280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16295,7 +16295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16313,7 +16313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16328,66 +16328,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16398,7 +16398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16406,7 +16406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16415,7 +16415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16423,102 +16423,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16526,40 +16526,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16568,7 +16568,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16577,7 +16577,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16585,7 +16585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16593,7 +16593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16603,7 +16603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16611,7 +16611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16619,7 +16619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16629,7 +16629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16639,7 +16639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16647,7 +16647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16655,7 +16655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16665,7 +16665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16673,11 +16673,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16685,7 +16685,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16694,7 +16694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16702,11 +16702,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16714,7 +16714,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16723,7 +16723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16732,7 +16732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16741,7 +16741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16750,7 +16750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16763,7 +16763,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16775,7 +16775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16790,31 +16790,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16824,11 +16824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16838,11 +16838,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16852,11 +16852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16866,11 +16866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16880,18 +16880,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16899,18 +16899,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16920,7 +16920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16930,102 +16930,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17033,28 +17033,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17062,7 +17062,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17070,7 +17070,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17080,31 +17080,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17118,7 +17118,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17132,15 +17132,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17149,7 +17149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17157,7 +17157,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17166,22 +17166,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17189,40 +17189,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17230,11 +17230,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17242,11 +17242,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17254,11 +17254,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17266,14 +17266,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17447,7 +17447,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17461,7 +17461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17473,7 +17473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17485,11 +17485,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17497,15 +17497,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17592,7 +17592,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17604,27 +17604,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17634,7 +17634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17642,7 +17642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17650,23 +17650,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17675,7 +17675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17851,82 +17851,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17935,18 +17935,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17955,7 +17955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17964,23 +17964,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17996,7 +17996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18014,7 +18014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18027,7 +18027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18040,7 +18040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18053,7 +18053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18063,19 +18063,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18334,7 +18334,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18342,7 +18342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18351,7 +18351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18360,22 +18360,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18383,15 +18383,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18478,66 +18478,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18546,7 +18546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18554,7 +18554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18562,7 +18562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18643,7 +18643,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18662,7 +18662,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18670,47 +18670,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19004,51 +19004,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19074,15 +19074,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19090,18 +19090,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19109,79 +19109,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19190,11 +19190,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19203,7 +19203,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19212,12 +19212,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19226,7 +19226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19235,7 +19235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19243,7 +19243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19255,7 +19255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19267,7 +19267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19287,7 +19287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19298,7 +19298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19312,7 +19312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19324,7 +19324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19335,7 +19335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19348,7 +19348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19360,7 +19360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19370,7 +19370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19380,31 +19380,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19415,7 +19415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19426,7 +19426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19439,7 +19439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19450,19 +19450,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19470,19 +19470,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19490,7 +19490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19500,7 +19500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19508,26 +19508,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19536,7 +19536,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19544,11 +19544,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19556,11 +19556,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19570,7 +19570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19580,7 +19580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19591,7 +19591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19599,7 +19599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20100,27 +20100,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20128,51 +20128,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20185,15 +20185,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20201,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20209,7 +20209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20217,15 +20217,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20233,68 +20233,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20302,7 +20302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20310,25 +20310,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20336,14 +20336,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20351,7 +20351,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20359,7 +20359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20367,14 +20367,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20396,23 +20396,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20420,23 +20420,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20445,19 +20445,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20465,7 +20465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20473,7 +20473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20481,11 +20481,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20493,55 +20493,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20549,7 +20549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20557,25 +20557,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20583,19 +20583,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20603,23 +20603,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20627,33 +20627,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20661,22 +20661,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20726,19 +20726,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20746,15 +20746,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20762,15 +20762,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20778,7 +20778,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20786,21 +20786,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20809,7 +20809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20821,7 +20821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20833,7 +20833,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20845,19 +20845,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20865,33 +20865,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20900,11 +20900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20914,7 +20914,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20924,7 +20924,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20934,19 +20934,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20954,18 +20954,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20974,7 +20974,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20983,33 +20983,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21033,11 +21033,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21045,18 +21045,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21064,7 +21064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21072,7 +21072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21080,21 +21080,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21123,23 +21123,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21147,11 +21147,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21160,7 +21160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21169,15 +21169,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21185,7 +21185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21193,7 +21193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21202,7 +21202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21211,7 +21211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21220,7 +21220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21229,7 +21229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21238,259 +21238,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21498,11 +21498,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21512,7 +21512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21520,14 +21520,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21537,7 +21537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21545,42 +21545,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21589,7 +21589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22162,11 +22162,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22174,7 +22174,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22182,54 +22182,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22237,23 +22237,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22261,7 +22261,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22270,44 +22270,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22315,34 +22315,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22350,26 +22350,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22377,18 +22377,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22396,38 +22396,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22435,25 +22435,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22461,7 +22461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22469,23 +22469,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22493,26 +22493,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22520,26 +22520,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22547,7 +22547,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22557,7 +22557,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22567,7 +22567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22577,7 +22577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22589,7 +22589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22600,15 +22600,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22616,18 +22616,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22635,7 +22635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22643,28 +22643,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22674,7 +22674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22684,7 +22684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22694,37 +22694,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22734,66 +22734,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22802,19 +22802,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22823,7 +22823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22831,7 +22831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22840,7 +22840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22849,15 +22849,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22866,11 +22866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22879,7 +22879,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22889,7 +22889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22898,7 +22898,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22908,11 +22908,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22920,7 +22920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22928,7 +22928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22936,21 +22936,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22958,7 +22958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22967,7 +22967,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22977,11 +22977,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22989,7 +22989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22997,28 +22997,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23028,7 +23028,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23038,7 +23038,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23048,7 +23048,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23058,7 +23058,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23068,7 +23068,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23078,14 +23078,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23094,7 +23094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23103,34 +23103,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23138,26 +23138,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23168,7 +23168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23178,11 +23178,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23190,19 +23190,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23219,19 +23219,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23318,15 +23318,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23334,14 +23334,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23460,18 +23460,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23479,7 +23479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23487,202 +23487,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23690,15 +23690,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23707,50 +23707,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23759,7 +23759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23769,7 +23769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23777,7 +23777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23785,7 +23785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23793,19 +23793,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23814,11 +23814,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23826,81 +23826,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23909,11 +23909,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23921,7 +23921,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23933,105 +23933,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24039,7 +24039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24047,20 +24047,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24068,7 +24068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24076,42 +24076,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24123,14 +24123,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24140,7 +24140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24150,7 +24150,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24160,7 +24160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24172,7 +24172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24183,7 +24183,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24197,7 +24197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24206,7 +24206,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24216,7 +24216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24226,7 +24226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24237,7 +24237,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24251,7 +24251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24260,7 +24260,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24269,11 +24269,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24282,7 +24282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24291,7 +24291,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24300,15 +24300,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24317,7 +24317,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24326,15 +24326,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24343,7 +24343,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24352,23 +24352,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24377,7 +24377,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24386,15 +24386,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24403,7 +24403,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24412,15 +24412,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24429,7 +24429,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24438,15 +24438,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24455,7 +24455,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24464,21 +24464,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24487,7 +24487,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24496,7 +24496,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24508,7 +24508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24520,7 +24520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24529,7 +24529,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24538,15 +24538,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24555,7 +24555,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24564,15 +24564,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24581,7 +24581,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24590,7 +24590,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24602,7 +24602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24614,7 +24614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24623,7 +24623,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24632,15 +24632,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24649,7 +24649,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24658,15 +24658,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24675,7 +24675,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24684,7 +24684,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24696,7 +24696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24708,7 +24708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24717,7 +24717,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24726,15 +24726,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24752,15 +24752,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24769,7 +24769,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24778,7 +24778,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24790,7 +24790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24802,7 +24802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24811,7 +24811,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24820,15 +24820,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24840,7 +24840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24852,7 +24852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24864,7 +24864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24876,7 +24876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24885,7 +24885,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24897,7 +24897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24909,7 +24909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24921,7 +24921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24930,7 +24930,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24942,7 +24942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24955,7 +24955,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24969,7 +24969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24977,7 +24977,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24985,7 +24985,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24994,11 +24994,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25006,27 +25006,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25036,7 +25036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25044,7 +25044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25059,74 +25059,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25227,19 +25227,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25304,11 +25304,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25395,11 +25395,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25407,27 +25407,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25502,15 +25502,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25523,7 +25523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25538,18 +25538,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25558,14 +25558,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25574,7 +25574,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25585,7 +25585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25594,7 +25594,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25606,7 +25606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25618,18 +25618,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25637,14 +25637,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25652,7 +25652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25666,7 +25666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25681,7 +25681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25694,7 +25694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25709,7 +25709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27417,15 +27417,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27433,26 +27433,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27460,14 +27460,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27699,15 +27699,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27715,26 +27715,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27742,26 +27742,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27769,29 +27769,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27799,19 +27799,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27819,18 +27819,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27838,7 +27838,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27846,15 +27846,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27862,26 +27862,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27889,22 +27889,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27912,14 +27912,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27927,7 +27927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27935,14 +27935,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27950,15 +27950,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27966,33 +27966,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28000,26 +28000,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28027,26 +28027,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28054,26 +28054,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28081,26 +28081,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28108,26 +28108,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28135,26 +28135,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28162,26 +28162,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28189,26 +28189,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28216,38 +28216,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28255,26 +28255,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28282,70 +28282,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28356,7 +28356,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28364,7 +28364,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28374,7 +28374,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28472,7 +28472,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28483,11 +28483,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28496,7 +28496,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28505,7 +28505,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28514,7 +28514,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28523,7 +28523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28532,7 +28532,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28541,7 +28541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28550,67 +28550,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28619,14 +28619,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28634,7 +28634,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28644,7 +28644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28653,7 +28653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28662,7 +28662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28671,7 +28671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28681,11 +28681,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28693,70 +28693,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28774,43 +28774,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28820,7 +28820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28829,7 +28829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28838,7 +28838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28846,11 +28846,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28916,119 +28916,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29036,7 +29036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29044,15 +29044,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29060,220 +29060,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29286,7 +29286,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29299,71 +29299,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29371,7 +29371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29379,7 +29379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29387,7 +29387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29395,26 +29395,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29422,7 +29422,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29430,7 +29430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29440,7 +29440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29450,19 +29450,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29470,7 +29470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29478,7 +29478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29487,7 +29487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29496,7 +29496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29504,7 +29504,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29512,7 +29512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29520,7 +29520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29528,7 +29528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29536,7 +29536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29544,7 +29544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29552,7 +29552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29560,29 +29560,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29671,18 +29671,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29707,149 +29707,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29857,11 +29857,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29870,23 +29870,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29899,7 +29899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29908,7 +29908,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29917,27 +29917,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29945,7 +29945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29953,7 +29953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -29961,29 +29961,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -29991,25 +29991,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30017,7 +30017,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30025,7 +30025,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30033,22 +30033,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30056,19 +30056,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30076,7 +30076,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30084,19 +30084,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30104,34 +30104,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30139,7 +30139,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30147,44 +30147,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30193,7 +30193,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30201,7 +30201,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30210,13 +30210,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30230,7 +30230,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30243,11 +30243,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30255,7 +30255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30263,7 +30263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30355,14 +30355,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30370,15 +30370,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30386,7 +30386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30394,29 +30394,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30424,11 +30424,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30436,7 +30436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30444,21 +30444,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30471,7 +30471,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30488,7 +30488,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30498,7 +30498,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30508,15 +30508,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30527,7 +30527,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30538,83 +30538,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30622,19 +30622,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30647,51 +30647,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30699,7 +30699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30707,87 +30707,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30800,18 +30800,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30819,7 +30819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30827,7 +30827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30844,7 +30844,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30852,11 +30852,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30866,7 +30866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30874,7 +30874,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30895,7 +30895,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30904,7 +30904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30919,7 +30919,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30936,7 +30936,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30944,7 +30944,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -30955,29 +30955,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31054,29 +31054,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31092,7 +31092,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31108,7 +31108,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31122,7 +31122,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31136,29 +31136,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31167,7 +31167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31280,22 +31280,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31304,25 +31304,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31330,7 +31330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31338,11 +31338,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31350,35 +31350,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31400,21 +31400,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31422,7 +31422,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31430,7 +31430,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31438,7 +31438,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31449,19 +31449,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31471,12 +31471,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31484,34 +31484,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31519,14 +31519,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31536,7 +31536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31544,14 +31544,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31561,7 +31561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31569,14 +31569,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31586,7 +31586,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31595,11 +31595,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31607,26 +31607,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31636,11 +31636,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31648,7 +31648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31665,11 +31665,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31686,11 +31686,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31699,7 +31699,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31707,14 +31707,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31724,46 +31724,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -31957,7 +31957,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -31966,7 +31966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31975,7 +31975,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31984,19 +31984,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32009,7 +32009,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32021,7 +32021,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32034,7 +32034,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32046,77 +32046,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32124,11 +32124,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32139,126 +32139,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32271,7 +32271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32284,98 +32284,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32383,7 +32383,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32395,11 +32395,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32407,61 +32407,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32474,7 +32474,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32487,7 +32487,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32495,7 +32495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32503,14 +32503,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
@@ -32593,26 +32593,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32625,11 +32625,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32637,7 +32637,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32645,15 +32645,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32663,42 +32663,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32706,33 +32706,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32740,11 +32740,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32756,14 +32756,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/linux_x86_64_crypto.rs
+++ b/aws-lc-fips-sys/src/linux_x86_64_crypto.rs
@@ -4539,38 +4539,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4579,18 +4579,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4599,18 +4599,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4619,7 +4619,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4627,11 +4627,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4642,30 +4642,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4704,30 +4704,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4737,15 +4737,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4809,7 +4809,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4817,7 +4817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4825,15 +4825,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4845,7 +4845,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4854,7 +4854,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4865,7 +4865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4876,7 +4876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4888,7 +4888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4898,7 +4898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4908,7 +4908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4919,7 +4919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5140,27 +5140,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5168,29 +5168,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5198,7 +5198,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5330,27 +5330,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5358,11 +5358,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5370,22 +5370,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5394,7 +5394,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5403,35 +5403,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5441,7 +5441,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5501,7 +5501,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5607,11 +5607,11 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5624,7 +5624,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5638,7 +5638,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5649,29 +5649,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5727,7 +5727,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5738,7 +5738,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5751,7 +5751,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5763,7 +5763,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5772,7 +5772,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5783,7 +5783,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5810,23 +5810,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5834,7 +5834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5842,7 +5842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5850,7 +5850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5858,15 +5858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5875,7 +5875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5883,7 +5883,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5892,67 +5892,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5978,7 +5978,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5986,68 +5986,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6055,7 +6055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6063,7 +6063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6072,11 +6072,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6085,15 +6085,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6101,11 +6101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6113,22 +6113,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6136,30 +6136,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6167,89 +6167,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6258,34 +6258,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6294,13 +6294,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6309,13 +6309,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6328,7 +6328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6341,7 +6341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6354,7 +6354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6366,7 +6366,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6380,7 +6380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6393,7 +6393,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6406,7 +6406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6418,46 +6418,46 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6469,7 +6469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6828,193 +6828,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7023,15 +7023,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7041,11 +7041,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7053,47 +7053,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7101,11 +7101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7113,43 +7113,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7158,7 +7158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7168,7 +7168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7177,7 +7177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7187,7 +7187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7196,7 +7196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7206,7 +7206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7215,7 +7215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7225,7 +7225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7234,7 +7234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7243,7 +7243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7251,7 +7251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7260,7 +7260,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7269,7 +7269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7278,11 +7278,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7290,7 +7290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7350,15 +7350,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7372,7 +7372,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7380,11 +7380,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7399,7 +7399,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7409,7 +7409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7420,7 +7420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7430,7 +7430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7439,7 +7439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7448,7 +7448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7457,7 +7457,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7467,7 +7467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7477,23 +7477,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7502,7 +7502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7511,7 +7511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7521,7 +7521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7530,7 +7530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7540,7 +7540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7551,7 +7551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7562,15 +7562,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7581,7 +7581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7594,11 +7594,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7606,7 +7606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7614,7 +7614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7762,15 +7762,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7794,15 +7794,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7811,7 +7811,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7819,14 +7819,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7834,7 +7834,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7842,7 +7842,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7850,7 +7850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7858,14 +7858,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7873,7 +7873,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7881,22 +7881,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7972,54 +7972,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8027,7 +8027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8035,79 +8035,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8115,7 +8115,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8123,7 +8123,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8131,7 +8131,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8139,7 +8139,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8147,7 +8147,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8155,7 +8155,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8163,7 +8163,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8171,7 +8171,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8179,117 +8179,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8297,14 +8297,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8314,7 +8314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8326,7 +8326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8336,7 +8336,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8346,15 +8346,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8362,26 +8362,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8389,23 +8389,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8413,14 +8413,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8428,25 +8428,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8454,7 +8454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8462,14 +8462,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8498,19 +8498,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8518,11 +8518,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8530,54 +8530,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8585,59 +8585,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8645,23 +8645,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8670,26 +8670,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8697,29 +8697,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8728,22 +8728,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8751,15 +8751,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8768,11 +8768,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8781,41 +8781,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8823,11 +8823,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8852,7 +8852,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8862,11 +8862,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8874,11 +8874,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8886,7 +8886,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9220,15 +9220,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9236,19 +9236,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9256,7 +9256,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9264,12 +9264,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9277,14 +9277,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9292,33 +9292,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9326,7 +9326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9334,19 +9334,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9354,7 +9354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9362,7 +9362,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9372,7 +9372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9382,11 +9382,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9394,33 +9394,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9428,34 +9428,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10065,7 +10065,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10090,19 +10090,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10112,19 +10112,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10134,7 +10134,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10142,11 +10142,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10156,7 +10156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10164,7 +10164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10374,11 +10374,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10386,11 +10386,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10445,19 +10445,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10466,7 +10466,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10527,23 +10527,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10551,82 +10551,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10634,7 +10634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10642,11 +10642,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10654,7 +10654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10663,7 +10663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10674,22 +10674,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10698,7 +10698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10707,7 +10707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10716,7 +10716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10725,33 +10725,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10759,7 +10759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10767,7 +10767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11074,23 +11074,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11098,40 +11098,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11139,15 +11139,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11155,55 +11155,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11211,11 +11211,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11223,7 +11223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11231,11 +11231,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11243,11 +11243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11258,114 +11258,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11376,7 +11376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11386,7 +11386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11396,7 +11396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11406,7 +11406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11414,7 +11414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11424,7 +11424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11432,7 +11432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11442,7 +11442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11450,47 +11450,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11499,45 +11499,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11550,23 +11550,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11576,7 +11576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11585,7 +11585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11594,7 +11594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11602,7 +11602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11610,7 +11610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11618,7 +11618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11627,110 +11627,110 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11967,7 +11967,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11977,19 +11977,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -11999,15 +11999,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12102,15 +12102,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12118,7 +12118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12126,14 +12126,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12141,7 +12141,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12149,23 +12149,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12173,15 +12173,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12268,11 +12268,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12280,19 +12280,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12300,19 +12300,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12410,11 +12410,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12422,19 +12422,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12442,15 +12442,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12548,11 +12548,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12560,34 +12560,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12595,34 +12595,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12630,7 +12630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12639,7 +12639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12648,21 +12648,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12670,7 +12670,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12678,7 +12678,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12686,7 +12686,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12695,7 +12695,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12703,11 +12703,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12734,51 +12734,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12788,70 +12788,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12859,15 +12859,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12876,7 +12876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12885,7 +12885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12896,7 +12896,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12906,11 +12906,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12921,7 +12921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -12994,15 +12994,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13011,7 +13011,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13022,7 +13022,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13033,7 +13033,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13046,7 +13046,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13058,7 +13058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13067,7 +13067,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13076,43 +13076,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13120,7 +13120,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13128,7 +13128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13137,7 +13137,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13146,40 +13146,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13188,11 +13188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13200,7 +13200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13211,19 +13211,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13231,19 +13231,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13258,7 +13258,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13266,14 +13266,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13281,114 +13281,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13396,11 +13396,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13408,7 +13408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13416,7 +13416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13424,7 +13424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13435,75 +13435,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13511,19 +13511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13615,15 +13615,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13631,11 +13631,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13643,15 +13643,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13697,43 +13697,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13741,7 +13741,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13750,7 +13750,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13758,7 +13758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13767,7 +13767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13779,11 +13779,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13837,28 +13837,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13867,7 +13867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13877,7 +13877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13888,7 +13888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13899,7 +13899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13910,47 +13910,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13960,7 +13960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13968,14 +13968,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -13983,11 +13983,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13995,11 +13995,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14007,11 +14007,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14019,7 +14019,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14175,19 +14175,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14195,19 +14195,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14215,7 +14215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14225,53 +14225,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14279,7 +14279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14288,7 +14288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14298,7 +14298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14308,7 +14308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14318,7 +14318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14328,7 +14328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14339,7 +14339,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14349,7 +14349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14359,7 +14359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14369,7 +14369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14379,7 +14379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14388,7 +14388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14396,7 +14396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14407,7 +14407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14416,7 +14416,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14425,7 +14425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14433,11 +14433,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14447,15 +14447,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14509,92 +14509,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14602,7 +14602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14611,15 +14611,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14627,11 +14627,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14639,22 +14639,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14664,7 +14664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14672,7 +14672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14794,11 +14794,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14806,11 +14806,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14818,11 +14818,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14830,14 +14830,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14854,7 +14854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14863,7 +14863,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14874,7 +14874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14885,7 +14885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14939,23 +14939,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14963,7 +14963,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -14971,7 +14971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -14979,7 +14979,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14988,19 +14988,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15008,11 +15008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15022,7 +15022,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15030,83 +15030,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15233,11 +15233,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15246,11 +15246,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15261,11 +15261,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15280,7 +15280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15295,7 +15295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15313,7 +15313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15328,66 +15328,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15398,7 +15398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15406,7 +15406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15415,7 +15415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15423,102 +15423,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15526,40 +15526,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15568,7 +15568,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15577,7 +15577,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15585,7 +15585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15593,7 +15593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15603,7 +15603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15611,7 +15611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15619,7 +15619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15629,7 +15629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15639,7 +15639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15647,7 +15647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15655,7 +15655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15665,7 +15665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15673,11 +15673,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15685,7 +15685,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15694,7 +15694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15702,11 +15702,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15714,7 +15714,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15723,7 +15723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15732,7 +15732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15741,7 +15741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15750,7 +15750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15763,7 +15763,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15775,7 +15775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15790,31 +15790,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15824,11 +15824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15838,11 +15838,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15852,11 +15852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15866,11 +15866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15880,18 +15880,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15899,18 +15899,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15920,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15930,102 +15930,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16033,28 +16033,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16062,7 +16062,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16070,7 +16070,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16080,31 +16080,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16118,7 +16118,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16132,15 +16132,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16149,7 +16149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16157,7 +16157,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16166,22 +16166,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16189,40 +16189,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16230,11 +16230,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16242,11 +16242,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16254,11 +16254,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16266,14 +16266,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16447,7 +16447,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16461,7 +16461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16473,7 +16473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16485,11 +16485,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16497,15 +16497,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16592,7 +16592,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16604,27 +16604,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16634,7 +16634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16642,7 +16642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16650,23 +16650,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16675,7 +16675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16851,82 +16851,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16935,18 +16935,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16955,7 +16955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16964,23 +16964,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16996,7 +16996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17014,7 +17014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17027,7 +17027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17040,7 +17040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17053,7 +17053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17063,19 +17063,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17334,7 +17334,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17342,7 +17342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17351,7 +17351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17360,22 +17360,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17383,15 +17383,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17478,66 +17478,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17546,7 +17546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17554,7 +17554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17562,7 +17562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17643,7 +17643,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17662,7 +17662,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17670,47 +17670,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18004,51 +18004,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18074,15 +18074,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18090,18 +18090,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18109,79 +18109,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18190,11 +18190,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18203,7 +18203,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18212,12 +18212,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18226,7 +18226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18235,7 +18235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18243,7 +18243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18255,7 +18255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18267,7 +18267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18277,7 +18277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18287,7 +18287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18298,7 +18298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18312,7 +18312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18324,7 +18324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18335,7 +18335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18348,7 +18348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18360,7 +18360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18370,7 +18370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18380,31 +18380,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18415,7 +18415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18426,7 +18426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18439,7 +18439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18450,19 +18450,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18470,19 +18470,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18490,7 +18490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18500,7 +18500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18508,26 +18508,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18536,7 +18536,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18544,11 +18544,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18556,11 +18556,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18570,7 +18570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18580,7 +18580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18591,7 +18591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18599,7 +18599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19100,27 +19100,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19128,51 +19128,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19185,15 +19185,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19201,7 +19201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19209,7 +19209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19217,15 +19217,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19233,68 +19233,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19302,7 +19302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19310,25 +19310,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19336,14 +19336,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19351,7 +19351,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19359,7 +19359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19367,14 +19367,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19396,23 +19396,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19420,23 +19420,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19445,19 +19445,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19465,7 +19465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19473,7 +19473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19481,11 +19481,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19493,55 +19493,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19549,7 +19549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19557,25 +19557,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19583,19 +19583,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19603,23 +19603,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19627,33 +19627,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19661,22 +19661,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19726,19 +19726,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19746,15 +19746,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19762,15 +19762,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19778,7 +19778,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19786,21 +19786,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19809,7 +19809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19821,7 +19821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19833,7 +19833,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19845,19 +19845,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19865,33 +19865,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19900,11 +19900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19914,7 +19914,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19924,7 +19924,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19934,19 +19934,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19954,18 +19954,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19974,7 +19974,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19983,33 +19983,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20033,11 +20033,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20045,18 +20045,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20064,7 +20064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20072,7 +20072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20080,21 +20080,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20123,23 +20123,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20147,11 +20147,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20160,7 +20160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20169,15 +20169,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20185,7 +20185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20193,7 +20193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20202,7 +20202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20211,7 +20211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20220,7 +20220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20229,7 +20229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20238,259 +20238,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20498,11 +20498,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20512,7 +20512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20520,14 +20520,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20537,7 +20537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20545,42 +20545,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20589,7 +20589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21162,11 +21162,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21174,7 +21174,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21182,54 +21182,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21237,23 +21237,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21261,7 +21261,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21270,44 +21270,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21315,34 +21315,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21350,26 +21350,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21377,18 +21377,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21396,38 +21396,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21435,25 +21435,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21461,7 +21461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21469,23 +21469,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21493,26 +21493,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21520,26 +21520,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21547,7 +21547,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21557,7 +21557,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21567,7 +21567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21577,7 +21577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21589,7 +21589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21600,15 +21600,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21616,18 +21616,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21635,7 +21635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21643,28 +21643,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21674,7 +21674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21684,7 +21684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21694,37 +21694,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21734,66 +21734,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21802,19 +21802,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21823,7 +21823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21831,7 +21831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21840,7 +21840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21849,15 +21849,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21866,11 +21866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21879,7 +21879,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21889,7 +21889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21898,7 +21898,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21908,11 +21908,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21920,7 +21920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21928,7 +21928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21936,21 +21936,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21958,7 +21958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21967,7 +21967,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21977,11 +21977,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21989,7 +21989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21997,28 +21997,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22028,7 +22028,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22038,7 +22038,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22048,7 +22048,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22058,7 +22058,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22068,7 +22068,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22078,14 +22078,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22094,7 +22094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22103,34 +22103,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22138,26 +22138,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22168,7 +22168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22178,11 +22178,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22190,19 +22190,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22219,19 +22219,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22318,15 +22318,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22334,14 +22334,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22460,18 +22460,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22479,7 +22479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22487,202 +22487,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22690,15 +22690,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22707,50 +22707,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22759,7 +22759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22769,7 +22769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22777,7 +22777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22785,7 +22785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22793,19 +22793,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22814,11 +22814,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22826,81 +22826,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22909,11 +22909,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22921,7 +22921,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22933,105 +22933,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23039,7 +23039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23047,20 +23047,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23068,7 +23068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23076,42 +23076,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23123,14 +23123,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23140,7 +23140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23150,7 +23150,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23160,7 +23160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23172,7 +23172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23183,7 +23183,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23197,7 +23197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23206,7 +23206,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23216,7 +23216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23226,7 +23226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23237,7 +23237,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23251,7 +23251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23260,7 +23260,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23269,11 +23269,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23282,7 +23282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23291,7 +23291,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23300,15 +23300,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23317,7 +23317,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23326,15 +23326,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23343,7 +23343,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23352,23 +23352,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23377,7 +23377,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23386,15 +23386,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23403,7 +23403,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23412,15 +23412,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23429,7 +23429,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23438,15 +23438,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23455,7 +23455,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23464,21 +23464,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23487,7 +23487,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23496,7 +23496,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23508,7 +23508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23520,7 +23520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23529,7 +23529,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23538,15 +23538,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23555,7 +23555,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23564,15 +23564,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23581,7 +23581,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23590,7 +23590,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23602,7 +23602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23614,7 +23614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23623,7 +23623,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23632,15 +23632,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23649,7 +23649,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23658,15 +23658,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23675,7 +23675,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23684,7 +23684,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23696,7 +23696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23708,7 +23708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23717,7 +23717,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23726,15 +23726,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23743,7 +23743,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23752,15 +23752,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23769,7 +23769,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23778,7 +23778,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23790,7 +23790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23802,7 +23802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23811,7 +23811,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23820,15 +23820,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23840,7 +23840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23852,7 +23852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23864,7 +23864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23876,7 +23876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23885,7 +23885,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23897,7 +23897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23909,7 +23909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23921,7 +23921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23930,7 +23930,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23942,7 +23942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23955,7 +23955,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -23969,7 +23969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -23977,7 +23977,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -23985,7 +23985,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -23994,11 +23994,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24006,27 +24006,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24036,7 +24036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24044,7 +24044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24059,74 +24059,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24227,19 +24227,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24304,11 +24304,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24395,11 +24395,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24407,27 +24407,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24502,15 +24502,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24523,7 +24523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24538,18 +24538,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24558,14 +24558,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24574,7 +24574,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24585,7 +24585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24594,7 +24594,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24606,7 +24606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24618,18 +24618,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24637,14 +24637,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24652,7 +24652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24666,7 +24666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24681,7 +24681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24694,7 +24694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24709,7 +24709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26417,15 +26417,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26433,26 +26433,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26460,14 +26460,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26699,15 +26699,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26715,26 +26715,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26742,26 +26742,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26769,29 +26769,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26799,19 +26799,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26819,18 +26819,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26838,7 +26838,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26846,15 +26846,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26862,26 +26862,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26889,22 +26889,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26912,14 +26912,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26927,7 +26927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26935,14 +26935,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26950,15 +26950,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26966,33 +26966,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27000,26 +27000,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27027,26 +27027,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27054,26 +27054,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27081,26 +27081,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27108,26 +27108,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27135,26 +27135,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27162,26 +27162,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27189,26 +27189,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27216,38 +27216,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27255,26 +27255,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27282,70 +27282,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27356,7 +27356,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27364,7 +27364,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27374,7 +27374,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27472,7 +27472,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27483,11 +27483,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27496,7 +27496,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27505,7 +27505,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27514,7 +27514,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27523,7 +27523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27532,7 +27532,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27541,7 +27541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27550,67 +27550,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27619,14 +27619,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27634,7 +27634,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27644,7 +27644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27653,7 +27653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27662,7 +27662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27671,7 +27671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27681,11 +27681,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27693,70 +27693,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27774,43 +27774,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27820,7 +27820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27829,7 +27829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27838,7 +27838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27846,11 +27846,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/linux_x86_64_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/linux_x86_64_crypto_ssl.rs
@@ -5539,38 +5539,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5579,18 +5579,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5599,18 +5599,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5619,7 +5619,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5627,11 +5627,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5642,30 +5642,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5704,30 +5704,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5737,15 +5737,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5809,7 +5809,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5817,7 +5817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5825,15 +5825,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5845,7 +5845,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5854,7 +5854,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5865,7 +5865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5876,7 +5876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5888,7 +5888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5898,7 +5898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5908,7 +5908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5919,7 +5919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -6140,27 +6140,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -6168,29 +6168,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6198,7 +6198,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6330,27 +6330,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6358,11 +6358,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6370,22 +6370,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6394,7 +6394,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6403,35 +6403,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6441,7 +6441,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6501,7 +6501,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6607,11 +6607,11 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6624,7 +6624,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6638,7 +6638,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6649,29 +6649,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6727,7 +6727,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6738,7 +6738,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6751,7 +6751,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6763,7 +6763,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6772,7 +6772,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6783,7 +6783,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6810,23 +6810,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6834,7 +6834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6842,7 +6842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6850,7 +6850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6858,15 +6858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6875,7 +6875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6883,7 +6883,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6892,67 +6892,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6978,7 +6978,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6986,68 +6986,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7055,7 +7055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7063,7 +7063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7072,11 +7072,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7085,15 +7085,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7101,11 +7101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7113,22 +7113,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7136,30 +7136,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7167,89 +7167,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7258,34 +7258,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7294,13 +7294,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7309,13 +7309,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7328,7 +7328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7341,7 +7341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7354,7 +7354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7366,7 +7366,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7380,7 +7380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7393,7 +7393,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7406,7 +7406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7418,46 +7418,46 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7469,7 +7469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7828,193 +7828,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8023,15 +8023,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8041,11 +8041,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8053,47 +8053,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8101,11 +8101,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8113,43 +8113,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8158,7 +8158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8168,7 +8168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8177,7 +8177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8187,7 +8187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8196,7 +8196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8206,7 +8206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8215,7 +8215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8225,7 +8225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8234,7 +8234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8243,7 +8243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8251,7 +8251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8260,7 +8260,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8269,7 +8269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8278,11 +8278,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8290,7 +8290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8350,15 +8350,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8372,7 +8372,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8380,11 +8380,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8399,7 +8399,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8409,7 +8409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8420,7 +8420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8430,7 +8430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8439,7 +8439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8448,7 +8448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8457,7 +8457,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8467,7 +8467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8477,23 +8477,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8502,7 +8502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8511,7 +8511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8521,7 +8521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8530,7 +8530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8540,7 +8540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8551,7 +8551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8562,15 +8562,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8581,7 +8581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8594,11 +8594,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8606,7 +8606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8614,7 +8614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8762,15 +8762,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8794,15 +8794,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8811,7 +8811,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8819,14 +8819,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8834,7 +8834,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8842,7 +8842,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8850,7 +8850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8858,14 +8858,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8873,7 +8873,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8881,22 +8881,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8972,54 +8972,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9027,7 +9027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9035,79 +9035,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9115,7 +9115,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9123,7 +9123,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9131,7 +9131,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9139,7 +9139,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9147,7 +9147,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9155,7 +9155,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9163,7 +9163,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9171,7 +9171,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9179,117 +9179,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9297,14 +9297,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9314,7 +9314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9326,7 +9326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9336,7 +9336,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9346,15 +9346,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9362,26 +9362,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9389,23 +9389,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9413,14 +9413,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9428,25 +9428,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9454,7 +9454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9462,14 +9462,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9498,19 +9498,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9518,11 +9518,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9530,54 +9530,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9585,59 +9585,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9645,23 +9645,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9670,26 +9670,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9697,29 +9697,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9728,22 +9728,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9751,15 +9751,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9768,11 +9768,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9781,41 +9781,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9823,11 +9823,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9852,7 +9852,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9862,11 +9862,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9874,11 +9874,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9886,7 +9886,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10220,15 +10220,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10236,19 +10236,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10256,7 +10256,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10264,12 +10264,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10277,14 +10277,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10292,33 +10292,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10326,7 +10326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10334,19 +10334,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10354,7 +10354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10362,7 +10362,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10372,7 +10372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10382,11 +10382,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10394,33 +10394,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10428,34 +10428,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11065,7 +11065,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11090,19 +11090,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11112,19 +11112,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11134,7 +11134,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11142,11 +11142,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11156,7 +11156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11164,7 +11164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11374,11 +11374,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11386,11 +11386,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11445,19 +11445,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11466,7 +11466,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11527,23 +11527,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11551,82 +11551,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11634,7 +11634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11642,11 +11642,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11654,7 +11654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11663,7 +11663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11674,22 +11674,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11698,7 +11698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11707,7 +11707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11716,7 +11716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11725,33 +11725,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11759,7 +11759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11767,7 +11767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12074,23 +12074,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12098,40 +12098,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12139,15 +12139,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12155,55 +12155,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12211,11 +12211,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12223,7 +12223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12231,11 +12231,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12243,11 +12243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12258,114 +12258,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12376,7 +12376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12386,7 +12386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12396,7 +12396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12406,7 +12406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12414,7 +12414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12424,7 +12424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12432,7 +12432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12442,7 +12442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12450,47 +12450,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12499,45 +12499,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12550,23 +12550,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12576,7 +12576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12585,7 +12585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12594,7 +12594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12602,7 +12602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12610,7 +12610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12618,7 +12618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12627,110 +12627,110 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12967,7 +12967,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12977,19 +12977,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12999,15 +12999,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13102,15 +13102,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13118,7 +13118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13126,14 +13126,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13141,7 +13141,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13149,23 +13149,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13173,15 +13173,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13268,11 +13268,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13280,19 +13280,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13300,19 +13300,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13410,11 +13410,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13422,19 +13422,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13442,15 +13442,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13548,11 +13548,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13560,34 +13560,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13595,34 +13595,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13630,7 +13630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13639,7 +13639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13648,21 +13648,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13670,7 +13670,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13678,7 +13678,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13686,7 +13686,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13695,7 +13695,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13703,11 +13703,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13734,51 +13734,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13788,70 +13788,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13859,15 +13859,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13876,7 +13876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13885,7 +13885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13896,7 +13896,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13906,11 +13906,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13921,7 +13921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13994,15 +13994,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14011,7 +14011,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14022,7 +14022,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14033,7 +14033,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14046,7 +14046,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14058,7 +14058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14067,7 +14067,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14076,43 +14076,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14120,7 +14120,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14128,7 +14128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14137,7 +14137,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14146,40 +14146,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14188,11 +14188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14200,7 +14200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14211,19 +14211,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14231,19 +14231,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14258,7 +14258,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14266,14 +14266,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14281,114 +14281,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14396,11 +14396,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14408,7 +14408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14416,7 +14416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14424,7 +14424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14435,75 +14435,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14511,19 +14511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14615,15 +14615,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14631,11 +14631,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14643,15 +14643,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14697,43 +14697,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14741,7 +14741,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14750,7 +14750,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14758,7 +14758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14767,7 +14767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14779,11 +14779,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14837,28 +14837,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14867,7 +14867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14877,7 +14877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14888,7 +14888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14899,7 +14899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14910,47 +14910,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14960,7 +14960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14968,14 +14968,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14983,11 +14983,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14995,11 +14995,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15007,11 +15007,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15019,7 +15019,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15175,19 +15175,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15195,19 +15195,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15215,7 +15215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15225,53 +15225,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15279,7 +15279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15288,7 +15288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15298,7 +15298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15308,7 +15308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15318,7 +15318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15328,7 +15328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15339,7 +15339,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15349,7 +15349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15359,7 +15359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15369,7 +15369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15379,7 +15379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15388,7 +15388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15396,7 +15396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15407,7 +15407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15416,7 +15416,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15425,7 +15425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15433,11 +15433,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15447,15 +15447,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15509,92 +15509,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15602,7 +15602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15611,15 +15611,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15627,11 +15627,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15639,22 +15639,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15664,7 +15664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15672,7 +15672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15794,11 +15794,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15806,11 +15806,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15818,11 +15818,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15830,14 +15830,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15854,7 +15854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15863,7 +15863,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15874,7 +15874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15885,7 +15885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15939,23 +15939,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15963,7 +15963,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15971,7 +15971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15979,7 +15979,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15988,19 +15988,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16008,11 +16008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16022,7 +16022,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16030,83 +16030,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16233,11 +16233,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16246,11 +16246,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16261,11 +16261,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16280,7 +16280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16295,7 +16295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16313,7 +16313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16328,66 +16328,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16398,7 +16398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16406,7 +16406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16415,7 +16415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16423,102 +16423,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16526,40 +16526,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16568,7 +16568,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16577,7 +16577,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16585,7 +16585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16593,7 +16593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16603,7 +16603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16611,7 +16611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16619,7 +16619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16629,7 +16629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16639,7 +16639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16647,7 +16647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16655,7 +16655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16665,7 +16665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16673,11 +16673,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16685,7 +16685,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16694,7 +16694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16702,11 +16702,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16714,7 +16714,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16723,7 +16723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16732,7 +16732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16741,7 +16741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16750,7 +16750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16763,7 +16763,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16775,7 +16775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16790,31 +16790,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16824,11 +16824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16838,11 +16838,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16852,11 +16852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16866,11 +16866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16880,18 +16880,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16899,18 +16899,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16920,7 +16920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16930,102 +16930,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17033,28 +17033,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17062,7 +17062,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17070,7 +17070,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17080,31 +17080,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17118,7 +17118,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17132,15 +17132,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17149,7 +17149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17157,7 +17157,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17166,22 +17166,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17189,40 +17189,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17230,11 +17230,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17242,11 +17242,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17254,11 +17254,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17266,14 +17266,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17447,7 +17447,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17461,7 +17461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17473,7 +17473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17485,11 +17485,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17497,15 +17497,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17592,7 +17592,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17604,27 +17604,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17634,7 +17634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17642,7 +17642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17650,23 +17650,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17675,7 +17675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17851,82 +17851,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17935,18 +17935,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17955,7 +17955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17964,23 +17964,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17996,7 +17996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18014,7 +18014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18027,7 +18027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18040,7 +18040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18053,7 +18053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18063,19 +18063,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18334,7 +18334,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18342,7 +18342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18351,7 +18351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18360,22 +18360,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18383,15 +18383,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18478,66 +18478,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18546,7 +18546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18554,7 +18554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18562,7 +18562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18643,7 +18643,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18662,7 +18662,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18670,47 +18670,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19004,51 +19004,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19074,15 +19074,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19090,18 +19090,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19109,79 +19109,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19190,11 +19190,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19203,7 +19203,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19212,12 +19212,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19226,7 +19226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19235,7 +19235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19243,7 +19243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19255,7 +19255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19267,7 +19267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19287,7 +19287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19298,7 +19298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19312,7 +19312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19324,7 +19324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19335,7 +19335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19348,7 +19348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19360,7 +19360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19370,7 +19370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19380,31 +19380,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19415,7 +19415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19426,7 +19426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19439,7 +19439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19450,19 +19450,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19470,19 +19470,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19490,7 +19490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19500,7 +19500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19508,26 +19508,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19536,7 +19536,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19544,11 +19544,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19556,11 +19556,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19570,7 +19570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19580,7 +19580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19591,7 +19591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19599,7 +19599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20100,27 +20100,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20128,51 +20128,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20185,15 +20185,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20201,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20209,7 +20209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20217,15 +20217,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20233,68 +20233,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20302,7 +20302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20310,25 +20310,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20336,14 +20336,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20351,7 +20351,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20359,7 +20359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20367,14 +20367,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20396,23 +20396,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20420,23 +20420,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20445,19 +20445,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20465,7 +20465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20473,7 +20473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20481,11 +20481,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20493,55 +20493,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20549,7 +20549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20557,25 +20557,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20583,19 +20583,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20603,23 +20603,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20627,33 +20627,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20661,22 +20661,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20726,19 +20726,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20746,15 +20746,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20762,15 +20762,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20778,7 +20778,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20786,21 +20786,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20809,7 +20809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20821,7 +20821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20833,7 +20833,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20845,19 +20845,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20865,33 +20865,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20900,11 +20900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20914,7 +20914,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20924,7 +20924,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20934,19 +20934,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20954,18 +20954,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20974,7 +20974,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20983,33 +20983,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21033,11 +21033,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21045,18 +21045,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21064,7 +21064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21072,7 +21072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21080,21 +21080,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21123,23 +21123,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21147,11 +21147,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21160,7 +21160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21169,15 +21169,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21185,7 +21185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21193,7 +21193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21202,7 +21202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21211,7 +21211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21220,7 +21220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21229,7 +21229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21238,259 +21238,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21498,11 +21498,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21512,7 +21512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21520,14 +21520,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21537,7 +21537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21545,42 +21545,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21589,7 +21589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22162,11 +22162,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22174,7 +22174,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22182,54 +22182,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22237,23 +22237,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22261,7 +22261,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22270,44 +22270,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22315,34 +22315,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22350,26 +22350,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22377,18 +22377,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22396,38 +22396,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22435,25 +22435,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22461,7 +22461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22469,23 +22469,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22493,26 +22493,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22520,26 +22520,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22547,7 +22547,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22557,7 +22557,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22567,7 +22567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22577,7 +22577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22589,7 +22589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22600,15 +22600,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22616,18 +22616,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22635,7 +22635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22643,28 +22643,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22674,7 +22674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22684,7 +22684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22694,37 +22694,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22734,66 +22734,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22802,19 +22802,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22823,7 +22823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22831,7 +22831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22840,7 +22840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22849,15 +22849,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22866,11 +22866,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22879,7 +22879,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22889,7 +22889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22898,7 +22898,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22908,11 +22908,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22920,7 +22920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22928,7 +22928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22936,21 +22936,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22958,7 +22958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22967,7 +22967,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22977,11 +22977,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22989,7 +22989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22997,28 +22997,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23028,7 +23028,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23038,7 +23038,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23048,7 +23048,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23058,7 +23058,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23068,7 +23068,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23078,14 +23078,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23094,7 +23094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23103,34 +23103,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23138,26 +23138,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23168,7 +23168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23178,11 +23178,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23190,19 +23190,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23219,19 +23219,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23318,15 +23318,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23334,14 +23334,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23460,18 +23460,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23479,7 +23479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23487,202 +23487,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23690,15 +23690,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23707,50 +23707,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23759,7 +23759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23769,7 +23769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23777,7 +23777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23785,7 +23785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23793,19 +23793,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23814,11 +23814,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23826,81 +23826,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23909,11 +23909,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23921,7 +23921,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23933,105 +23933,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24039,7 +24039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24047,20 +24047,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24068,7 +24068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24076,42 +24076,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24123,14 +24123,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24140,7 +24140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24150,7 +24150,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24160,7 +24160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24172,7 +24172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24183,7 +24183,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24197,7 +24197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24206,7 +24206,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24216,7 +24216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24226,7 +24226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24237,7 +24237,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24251,7 +24251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24260,7 +24260,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24269,11 +24269,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24282,7 +24282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24291,7 +24291,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24300,15 +24300,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24317,7 +24317,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24326,15 +24326,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24343,7 +24343,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24352,23 +24352,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24377,7 +24377,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24386,15 +24386,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24403,7 +24403,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24412,15 +24412,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24429,7 +24429,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24438,15 +24438,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24455,7 +24455,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24464,21 +24464,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24487,7 +24487,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24496,7 +24496,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24508,7 +24508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24520,7 +24520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24529,7 +24529,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24538,15 +24538,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24555,7 +24555,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24564,15 +24564,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24581,7 +24581,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24590,7 +24590,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24602,7 +24602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24614,7 +24614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24623,7 +24623,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24632,15 +24632,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24649,7 +24649,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24658,15 +24658,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24675,7 +24675,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24684,7 +24684,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24696,7 +24696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24708,7 +24708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24717,7 +24717,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24726,15 +24726,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24752,15 +24752,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24769,7 +24769,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24778,7 +24778,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24790,7 +24790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24802,7 +24802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24811,7 +24811,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24820,15 +24820,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24840,7 +24840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24852,7 +24852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24864,7 +24864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24876,7 +24876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24885,7 +24885,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24897,7 +24897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24909,7 +24909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24921,7 +24921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24930,7 +24930,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24942,7 +24942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24955,7 +24955,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24969,7 +24969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24977,7 +24977,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24985,7 +24985,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24994,11 +24994,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25006,27 +25006,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25036,7 +25036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25044,7 +25044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25059,74 +25059,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25227,19 +25227,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25304,11 +25304,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25395,11 +25395,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25407,27 +25407,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25502,15 +25502,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25523,7 +25523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25538,18 +25538,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25558,14 +25558,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25574,7 +25574,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25585,7 +25585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25594,7 +25594,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25606,7 +25606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25618,18 +25618,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25637,14 +25637,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25652,7 +25652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25666,7 +25666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25681,7 +25681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25694,7 +25694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25709,7 +25709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27417,15 +27417,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27433,26 +27433,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27460,14 +27460,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27699,15 +27699,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27715,26 +27715,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27742,26 +27742,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27769,29 +27769,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27799,19 +27799,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27819,18 +27819,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27838,7 +27838,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27846,15 +27846,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27862,26 +27862,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27889,22 +27889,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27912,14 +27912,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27927,7 +27927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27935,14 +27935,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27950,15 +27950,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27966,33 +27966,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28000,26 +28000,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28027,26 +28027,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28054,26 +28054,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28081,26 +28081,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28108,26 +28108,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28135,26 +28135,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28162,26 +28162,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28189,26 +28189,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28216,38 +28216,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28255,26 +28255,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28282,70 +28282,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28356,7 +28356,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28364,7 +28364,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28374,7 +28374,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28472,7 +28472,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28483,11 +28483,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28496,7 +28496,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28505,7 +28505,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28514,7 +28514,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28523,7 +28523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28532,7 +28532,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28541,7 +28541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28550,67 +28550,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28619,14 +28619,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28634,7 +28634,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28644,7 +28644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28653,7 +28653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28662,7 +28662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28671,7 +28671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28681,11 +28681,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28693,70 +28693,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28774,43 +28774,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28820,7 +28820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28829,7 +28829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28838,7 +28838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28846,11 +28846,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28916,119 +28916,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29036,7 +29036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29044,15 +29044,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29060,220 +29060,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29286,7 +29286,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29299,71 +29299,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29371,7 +29371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29379,7 +29379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29387,7 +29387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29395,26 +29395,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29422,7 +29422,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29430,7 +29430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29440,7 +29440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29450,19 +29450,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29470,7 +29470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29478,7 +29478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29487,7 +29487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29496,7 +29496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29504,7 +29504,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29512,7 +29512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29520,7 +29520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29528,7 +29528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29536,7 +29536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29544,7 +29544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29552,7 +29552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29560,29 +29560,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29671,18 +29671,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29707,149 +29707,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29857,11 +29857,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29870,23 +29870,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29899,7 +29899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29908,7 +29908,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29917,27 +29917,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29945,7 +29945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29953,7 +29953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -29961,29 +29961,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -29991,25 +29991,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30017,7 +30017,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30025,7 +30025,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30033,22 +30033,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30056,19 +30056,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30076,7 +30076,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30084,19 +30084,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30104,34 +30104,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30139,7 +30139,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30147,44 +30147,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30193,7 +30193,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30201,7 +30201,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30210,13 +30210,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30230,7 +30230,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30243,11 +30243,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30255,7 +30255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30263,7 +30263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30355,14 +30355,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30370,15 +30370,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30386,7 +30386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30394,29 +30394,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30424,11 +30424,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30436,7 +30436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30444,21 +30444,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30471,7 +30471,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30488,7 +30488,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30498,7 +30498,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30508,15 +30508,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30527,7 +30527,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30538,83 +30538,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30622,19 +30622,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30647,51 +30647,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30699,7 +30699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30707,87 +30707,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30800,18 +30800,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30819,7 +30819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30827,7 +30827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30844,7 +30844,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30852,11 +30852,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30866,7 +30866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30874,7 +30874,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30895,7 +30895,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30904,7 +30904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30919,7 +30919,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30936,7 +30936,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30944,7 +30944,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -30955,29 +30955,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31054,29 +31054,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31092,7 +31092,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31108,7 +31108,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31122,7 +31122,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31136,29 +31136,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31167,7 +31167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31280,22 +31280,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31304,25 +31304,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31330,7 +31330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31338,11 +31338,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31350,35 +31350,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31400,21 +31400,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31422,7 +31422,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31430,7 +31430,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31438,7 +31438,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31449,19 +31449,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31471,12 +31471,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31484,34 +31484,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31519,14 +31519,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31536,7 +31536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31544,14 +31544,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31561,7 +31561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31569,14 +31569,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31586,7 +31586,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31595,11 +31595,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31607,26 +31607,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31636,11 +31636,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31648,7 +31648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31665,11 +31665,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31686,11 +31686,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31699,7 +31699,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31707,14 +31707,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31724,46 +31724,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -31957,7 +31957,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -31966,7 +31966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31975,7 +31975,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31984,19 +31984,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32009,7 +32009,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32021,7 +32021,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32034,7 +32034,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32046,77 +32046,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32124,11 +32124,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32139,126 +32139,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32271,7 +32271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32284,98 +32284,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32383,7 +32383,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32395,11 +32395,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32407,61 +32407,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32474,7 +32474,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32487,7 +32487,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32495,7 +32495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32503,14 +32503,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
@@ -32593,26 +32593,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32625,11 +32625,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32637,7 +32637,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32645,15 +32645,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32663,42 +32663,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32706,33 +32706,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32740,11 +32740,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32756,14 +32756,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_7_0_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_7_1_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -31,7 +31,7 @@ fips = ["dep:aws-lc-fips-sys"]
 [dependencies]
 untrusted = { version = "0.7.1", optional = true }
 aws-lc-sys = { version = "0.6.0", path = "../aws-lc-sys", optional = true }
-aws-lc-fips-sys = { version = "0.7.0", path = "../aws-lc-fips-sys", optional = true }
+aws-lc-fips-sys = { version = "0.7.1", path = "../aws-lc-fips-sys", optional = true }
 zeroize = "1"
 mirai-annotations = "1.12.0"
 

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -17,7 +17,6 @@ include = [
     "/aws-lc/**/CMakeLists.txt",
     "/aws-lc/**/*.cmake",
     "/aws-lc/**/*.errordata",
-    "/aws-lc/**/*.go",
     "!/aws-lc/bindings/**",
     "!/aws-lc/docs/**",
     "!/aws-lc/fuzz/**",

--- a/scripts/publish/_prepublish_checks.sh
+++ b/scripts/publish/_prepublish_checks.sh
@@ -42,7 +42,7 @@ cargo clean --target-dir "${TEMP_TARGET_DIR}"
 cargo clippy --fix --allow-no-vcs
 cargo fmt
 cargo test --target-dir "${TEMP_TARGET_DIR}" # sanity check
-cargo package --target-dir "${TEMP_TARGET_DIR}" --no-verify # checks if published package will build.
+cargo package --target-dir "${TEMP_TARGET_DIR}" --allow-dirty # checks if published package will build.
 cargo clean --target-dir "${TEMP_TARGET_DIR}"
 
 popd &>/dev/null # "${CRATE_DIR}"

--- a/scripts/publish/_publish_tools.sh
+++ b/scripts/publish/_publish_tools.sh
@@ -48,10 +48,10 @@ function publish_crate {
 
   pushd "${CRATE_DIR}" &>/dev/null
 
-  cargo publish --dry-run
+  cargo publish --dry-run --allow-dirty
 
   if [[ ${PUBLISH} -eq 1 ]]; then
-    cargo publish
+    cargo publish --allow-dirty
   else
     echo Not published. Use -p to publish.
   fi

--- a/scripts/publish/publish-aws-lc-fips-sys.sh
+++ b/scripts/publish/publish-aws-lc-fips-sys.sh
@@ -6,13 +6,23 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 PUBLISH=0
+REPO_ROOT=$(git rev-parse --show-toplevel)
 RELATIVE_CRATE_PATH=aws-lc-fips-sys
+CRATE_DIR="${REPO_ROOT}/${RELATIVE_CRATE_PATH}"
 
 source "${SCRIPT_DIR}"/_publish_tools.sh
 
 publish_options "$@"
 
 pushd "${CRATE_DIR}" &>/dev/null
+
+cat << HERE > ./aws-lc/go.mod
+module boringssl.googlesource.com/boringssl
+
+go 1.13
+HERE
+
 run_prepublish_checks -c "${RELATIVE_CRATE_PATH}"
 publish_crate "${RELATIVE_CRATE_PATH}" ${PUBLISH}
+git --git-dir="${CRATE_DIR}/aws-lc/.git" restore go.mod
 popd &>/dev/null

--- a/scripts/publish/publish-aws-lc-sys.sh
+++ b/scripts/publish/publish-aws-lc-sys.sh
@@ -6,7 +6,9 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 PUBLISH=0
+REPO_ROOT=$(git rev-parse --show-toplevel)
 RELATIVE_CRATE_PATH=aws-lc-sys
+CRATE_DIR="${REPO_ROOT}/${RELATIVE_CRATE_PATH}"
 
 source "${SCRIPT_DIR}"/_publish_tools.sh
 


### PR DESCRIPTION
* Modified the aws-lc-fips-sys crate publish logic to strip the `aws-lc/go.mod` file.
* Bump aws-lc-fips-sys to 0.7.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
