### PR TITLE
Remove quic/new_mask indirection

### DIFF
--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -21,7 +21,8 @@ Consuming projects will need a C Compiler (Clang or GCC) and Cmake to build.
 
 **Requirements**:
 * C compiler (Clang or GCC)
-* Cmake (> v3.12) is required to build.
+* Cmake (> v3.12)
+* MacOS or Linux
 
 **Feature-specific Requirements**
   * Linux - required for `fips`
@@ -35,7 +36,7 @@ For those who would like to contribute to our project or build it directly from 
 a few more packages may be needed. The listing below shows the steps needed for you to begin
 building and testing our project locally.
 ```shell
-# Install CMake, Clang, Git, Libclang and Golang
+# Install dependencies needed for build and testing
 sudo yum install -y cmake3 clang git clang-libs golang openssl-devel
 
 # Install Rust

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -22,7 +22,7 @@ Consuming projects will need a C Compiler (Clang or GCC) and Cmake to build.
 **Requirements**:
 * C compiler (Clang or GCC)
 * Cmake (> v3.12)
-* Mac OS or Linux
+* Linux or [macOS](https://www.apple.com/macos)
 
 **Feature-specific Requirements**
   * Linux - required for `fips`

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -22,7 +22,7 @@ Consuming projects will need a C Compiler (Clang or GCC) and Cmake to build.
 **Requirements**:
 * C compiler (Clang or GCC)
 * Cmake (> v3.12)
-* MacOS or Linux
+* Mac OS or Linux
 
 **Feature-specific Requirements**
   * Linux - required for `fips`

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -54,7 +54,7 @@ impl HeaderProtectionKey {
     pub fn new_mask(&self, sample: &[u8]) -> Result<[u8; 5], error::Unspecified> {
         let sample = <&[u8; SAMPLE_LEN]>::try_from(sample)?;
 
-        let out = (self.algorithm.new_mask)(&self.inner, *sample);
+        let out = cipher_new_mask(&self.inner, *sample);
         Ok(out)
     }
 
@@ -74,8 +74,6 @@ pub type Sample = [u8; SAMPLE_LEN];
 /// A QUIC Header Protection Algorithm.
 pub struct Algorithm {
     init: fn(key: &[u8]) -> Result<KeyInner, error::Unspecified>,
-
-    new_mask: fn(key: &KeyInner, sample: Sample) -> [u8; 5],
 
     key_len: usize,
     id: AlgorithmID,
@@ -127,7 +125,6 @@ impl Eq for Algorithm {}
 pub static AES_128: Algorithm = Algorithm {
     key_len: 16,
     init: aes_init_128,
-    new_mask: cipher_new_mask,
     id: AlgorithmID::AES_128,
 };
 
@@ -135,7 +132,6 @@ pub static AES_128: Algorithm = Algorithm {
 pub static AES_256: Algorithm = Algorithm {
     key_len: 32,
     init: aes_init_256,
-    new_mask: cipher_new_mask,
     id: AlgorithmID::AES_256,
 };
 
@@ -143,7 +139,6 @@ pub static AES_256: Algorithm = Algorithm {
 pub static CHACHA20: Algorithm = Algorithm {
     key_len: 32,
     init: chacha20_init,
-    new_mask: cipher_new_mask,
     id: AlgorithmID::CHACHA20,
 };
 

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -21,7 +21,8 @@
 //!
 //! **Requirements**:
 //! * C compiler (Clang or GCC)
-//! * Cmake (> v3.12) is required to build.
+//! * Cmake (> v3.12)
+//! * MacOS or Linux
 //!
 //! **Feature-specific Requirements**
 //!   * Linux - required for `fips`
@@ -35,7 +36,7 @@
 //! a few more packages may be needed. The listing below shows the steps needed for you to begin
 //! building and testing our project locally.
 //! ```shell
-//! # Install CMake, Clang, Git, Libclang and Golang
+//! # Install dependencies needed for build and testing
 //! sudo yum install -y cmake3 clang git clang-libs golang openssl-devel
 //!
 //! # Install Rust

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -22,7 +22,7 @@
 //! **Requirements**:
 //! * C compiler (Clang or GCC)
 //! * Cmake (> v3.12)
-//! * Mac OS or Linux
+//! * Linux or [macOS](https://www.apple.com/macos)
 //!
 //! **Feature-specific Requirements**
 //!   * Linux - required for `fips`

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -22,7 +22,7 @@
 //! **Requirements**:
 //! * C compiler (Clang or GCC)
 //! * Cmake (> v3.12)
-//! * MacOS or Linux
+//! * Mac OS or Linux
 //!
 //! **Feature-specific Requirements**
 //!   * Linux - required for `fips`


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Remove unnecessary indirection in the quic/new-mask operation.
* Minor tweaks to documentation

### Call-outs:
N/A

### Testing:
`make test` succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
