### PR TITLE
Auto-generate bindings when needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         rust: [ stable ]
         os: [ ubuntu-latest, macOS-latest ]
         args:
-          - --no-default-features --features bindgen
+          - --no-default-features --features aws-lc-sys,bindgen
           - --release --all-targets --features ring-benchmarks,bindgen
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,30 @@ jobs:
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}
 
+  bindgen-test:
+    name: aws-lc-rs bindgen-tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable ]
+        os: [ ubuntu-latest, macOS-latest ]
+        args:
+          - --no-default-features --features bindgen
+          - --release --all-targets --features ring-benchmarks,bindgen
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Run cargo test
+        working-directory: ./aws-lc-rs
+        run: cargo test ${{ matrix.args }}
+
   windows-test:
     name: aws-lc-rs windows-tests
     runs-on: ${{ matrix.os }}
@@ -236,12 +260,13 @@ jobs:
         rust: [ stable ]
         os: [ windows-2019 ]
         args:
+          - --all-targets
           - --all-targets --features bindgen
-          - --release --all-targets --features ring-benchmarks,bindgen
-          - --no-default-features --features non-fips,bindgen
-          - --no-default-features --features non-fips,ring-io,bindgen
-          - --no-default-features --features non-fips,ring-sig-verify,bindgen
-          - --no-default-features --features non-fips,alloc,bindgen
+          - --release --all-targets --features ring-benchmarks
+          - --no-default-features --features non-fips
+          - --no-default-features --features non-fips,ring-io
+          - --no-default-features --features non-fips,ring-sig-verify
+          - --no-default-features --features non-fips,alloc
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,6 @@ api-diff-pub:
 	cargo public-api diff latest
 
 clippy:
-	cargo +nightly clippy --all-targets -- -W clippy::all  -W clippy::pedantic
+	cargo +nightly clippy --all-targets --features bindgen -- -W clippy::all  -W clippy::pedantic
 
 .PHONY: init-aws-lc-sys init-aws-lc-fips-sys init-submodules init update-submodules lic audit format api-diff-main api-diff-pub clippy

--- a/aws-lc-rs/Makefile
+++ b/aws-lc-rs/Makefile
@@ -26,6 +26,7 @@ coverage:
 test:
 	cargo test --all-targets --features ring-benchmarks
 	cargo test --release --all-targets
+	cargo test --release --all-targets --features bindgen
 ifeq ($(UNAME_S),Linux)
 	cargo test --release --all-targets --features fips
 	cargo test --no-default-features --features fips

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -44,12 +44,12 @@ build = "builder/main.rs"
 
 [features]
 asan = []
-bindgen = ["dep:bindgen"] # Generate the bindings on the targetted platform as a fallback mechanism.
+bindgen = [] # Generate the bindings on the targetted platform as a fallback mechanism.
 ssl = []
 
 [build-dependencies]
 cmake = "0.1.48"
-bindgen = { version = "0.65.1", optional = true }
+bindgen = { version = "0.65.1" }
 dunce = "1.0"
 
 [dependencies]

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -44,13 +44,19 @@ build = "builder/main.rs"
 
 [features]
 asan = []
-bindgen = [] # Generate the bindings on the targetted platform as a fallback mechanism.
 ssl = []
+bindgen = ["dep:bindgen"] # Generate the bindings on the targetted platform as a fallback mechanism.
 
 [build-dependencies]
 cmake = "0.1.48"
-bindgen = { version = "0.65.1" }
 dunce = "1.0"
+
+[target.'cfg(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.build-dependencies]
+bindgen = { version = "0.65.1", optional = true }
+
+[target.'cfg(not(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64"))))'.build-dependencies]
+bindgen = { version = "0.65.1" }
+
 
 [dependencies]
 libc = "0.2"

--- a/aws-lc-sys/builder/bindgen.rs
+++ b/aws-lc-sys/builder/bindgen.rs
@@ -22,7 +22,6 @@ impl StripPrefixCallback {
     }
 }
 
-#[cfg(feature = "bindgen")]
 impl ParseCallbacks for StripPrefixCallback {
     fn generated_name_override(&self, item_info: ItemInfo<'_>) -> Option<String> {
         self.remove_prefix.as_ref().and_then(|s| {
@@ -142,7 +141,7 @@ pub(crate) fn generate_bindings(
     manifest_dir: &Path,
     options: BindingOptions<'_>,
 ) -> Result<bindgen::Bindings, &'static str> {
-    let bindings = prepare_bindings_builder(&manifest_dir, options)
+    let bindings = prepare_bindings_builder(manifest_dir, options)
         .generate()
         .expect("Unable to generate bindings.");
     Ok(bindings)

--- a/aws-lc-sys/builder/bindgen.rs
+++ b/aws-lc-sys/builder/bindgen.rs
@@ -25,7 +25,7 @@ impl StripPrefixCallback {
 impl ParseCallbacks for StripPrefixCallback {
     fn generated_name_override(&self, item_info: ItemInfo<'_>) -> Option<String> {
         self.remove_prefix.as_ref().and_then(|s| {
-            let prefix = format!("{}_", s);
+            let prefix = format!("{s}_");
             item_info
                 .name
                 .strip_prefix(prefix.as_str())
@@ -34,7 +34,7 @@ impl ParseCallbacks for StripPrefixCallback {
     }
 }
 
-fn prepare_clang_args(manifest_dir: &Path, build_prefix: &Option<&str>) -> Vec<String> {
+fn prepare_clang_args(manifest_dir: &Path, build_prefix: Option<&str>) -> Vec<String> {
     let mut clang_args: Vec<String> = vec![
         "-I".to_string(),
         get_rust_include_path(manifest_dir).display().to_string(),
@@ -50,7 +50,7 @@ fn prepare_clang_args(manifest_dir: &Path, build_prefix: &Option<&str>) -> Vec<S
     }
 
     if let Some(prefix) = build_prefix {
-        clang_args.push(format!("-DBORINGSSL_PREFIX={}", prefix));
+        clang_args.push(format!("-DBORINGSSL_PREFIX={prefix}"));
         clang_args.push("-I".to_string());
         clang_args.push(
             get_generated_include_path(manifest_dir)
@@ -95,8 +95,8 @@ pub(crate) struct BindingOptions<'a> {
     pub disable_prelude: bool,
 }
 
-fn prepare_bindings_builder(manifest_dir: &Path, options: BindingOptions<'_>) -> bindgen::Builder {
-    let clang_args = prepare_clang_args(manifest_dir, &options.build_prefix);
+fn prepare_bindings_builder(manifest_dir: &Path, options: &BindingOptions<'_>) -> bindgen::Builder {
+    let clang_args = prepare_clang_args(manifest_dir, options.build_prefix);
 
     let mut builder = bindgen::Builder::default()
         .derive_copy(true)
@@ -139,10 +139,9 @@ fn prepare_bindings_builder(manifest_dir: &Path, options: BindingOptions<'_>) ->
 
 pub(crate) fn generate_bindings(
     manifest_dir: &Path,
-    options: BindingOptions<'_>,
-) -> Result<bindgen::Bindings, &'static str> {
-    let bindings = prepare_bindings_builder(manifest_dir, options)
+    options: &BindingOptions<'_>,
+) -> bindgen::Bindings {
+    prepare_bindings_builder(manifest_dir, options)
         .generate()
-        .expect("Unable to generate bindings.");
-    Ok(bindings)
+        .expect("Unable to generate bindings.")
 }

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -252,7 +252,7 @@ fn main() {
     cfg_bindgen_platform!(linux_aarch64, "linux", "aarch64", pregenerated);
     cfg_bindgen_platform!(macos_x86_64, "macos", "x86_64", pregenerated);
 
-    if is_bindgen_enabled && !(linux_x86 || linux_x86_64 || linux_aarch64 || macos_x86_64) {
+    if is_bindgen_enabled || !(linux_x86 || linux_x86_64 || linux_aarch64 || macos_x86_64) {
         emit_rustc_cfg("not_pregenerated");
     }
 

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -160,8 +160,7 @@ fn generate_bindings(manifest_dir: &Path, prefix: &str, bindings_path: &PathBuf)
         disable_prelude: true,
     };
 
-    let bindings =
-        bindgen::generate_bindings(manifest_dir, options).expect("Unable to generate bindings.");
+    let bindings = bindgen::generate_bindings(manifest_dir, &options);
 
     bindings
         .write(Box::new(std::fs::File::create(bindings_path).unwrap()))
@@ -172,25 +171,23 @@ fn generate_bindings(manifest_dir: &Path, prefix: &str, bindings_path: &PathBuf)
 fn generate_src_bindings(manifest_dir: &PathBuf, prefix: &str, src_bindings_path: &PathBuf) {
     bindgen::generate_bindings(
         &manifest_dir,
-        bindgen::BindingOptions {
+        &bindgen::BindingOptions {
             build_prefix: Some(&prefix),
             include_ssl: false,
             ..Default::default()
         },
     )
-    .expect("Unable to generate bindings.")
     .write_to_file(src_bindings_path.join(format!("{}.rs", target_platform_prefix("crypto"))))
     .expect("write bindings");
 
     bindgen::generate_bindings(
         &manifest_dir,
-        bindgen::BindingOptions {
+        &bindgen::BindingOptions {
             build_prefix: Some(&prefix),
             include_ssl: true,
             ..Default::default()
         },
     )
-    .expect("Unable to generate bindings.")
     .write_to_file(src_bindings_path.join(format!("{}.rs", target_platform_prefix("crypto_ssl"))))
     .expect("write bindings");
 }

--- a/aws-lc-sys/src/lib.rs
+++ b/aws-lc-sys/src/lib.rs
@@ -15,10 +15,10 @@ macro_rules! use_bindings {
 macro_rules! platform_binding {
     ($platform:ident) => {
         paste! {
-            #[cfg(all($platform, not(feature = "ssl")))]
+            #[cfg(all($platform, not(feature = "ssl"), not(not_pregenerated)))]
             use_bindings!([< $platform _crypto >]);
 
-            #[cfg(all($platform, feature = "ssl"))]
+            #[cfg(all($platform, feature = "ssl", not(not_pregenerated)))]
             use_bindings!([< $platform _crypto_ssl >]);
         }
     };

--- a/aws-lc-sys/src/lib.rs
+++ b/aws-lc-sys/src/lib.rs
@@ -4,11 +4,6 @@
 use paste::paste;
 use std::os::raw::{c_char, c_long, c_void};
 
-// Warn to use feature bindgen if building on a platform where prebuilt-bindings
-// aren't available
-#[cfg(all(not(feature = "bindgen"), not_pregenerated))]
-compile_error!("Prebuilt-bindings aren't available. Turn on feature bindgen to build.");
-
 #[allow(unused_macros)]
 macro_rules! use_bindings {
     ($bindings:ident) => {
@@ -37,7 +32,7 @@ platform_binding!(linux_aarch64);
 
 platform_binding!(macos_x86_64);
 
-#[cfg(all(feature = "bindgen", not_pregenerated))]
+#[cfg(not_pregenerated)]
 mod generated {
     #![allow(
         unused_imports,
@@ -60,7 +55,7 @@ mod generated {
 
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
-#[cfg(all(feature = "bindgen", not_pregenerated))]
+#[cfg(not_pregenerated)]
 pub use generated::*;
 
 #[allow(non_snake_case)]

--- a/aws-lc-sys/src/lib.rs
+++ b/aws-lc-sys/src/lib.rs
@@ -15,10 +15,10 @@ macro_rules! use_bindings {
 macro_rules! platform_binding {
     ($platform:ident) => {
         paste! {
-            #[cfg(all($platform, not(feature = "ssl"), not(not_pregenerated)))]
+            #[cfg(all($platform, not(feature = "ssl"), not(use_bindgen_generated)))]
             use_bindings!([< $platform _crypto >]);
 
-            #[cfg(all($platform, feature = "ssl", not(not_pregenerated)))]
+            #[cfg(all($platform, feature = "ssl", not(use_bindgen_generated)))]
             use_bindings!([< $platform _crypto_ssl >]);
         }
     };
@@ -32,7 +32,7 @@ platform_binding!(linux_aarch64);
 
 platform_binding!(macos_x86_64);
 
-#[cfg(not_pregenerated)]
+#[cfg(use_bindgen_generated)]
 mod generated {
     #![allow(
         unused_imports,
@@ -55,7 +55,7 @@ mod generated {
 
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
-#[cfg(not_pregenerated)]
+#[cfg(use_bindgen_generated)]
 pub use generated::*;
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* The build will automatically generate bindings when it finds that pre-generated bindings aren't available for current platform.
* This simplifies when `aws-lc-rs` is a transitive dependency and intermediary dependencies can't easily determine whether "bindgen" is needed.

### Call-outs:
N/A

### Testing:
* Tested on Mac, Linux and Windows hosts

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
