### PR TITLE
aws-lc-sys: only build libssl if needed

### DIFF
--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -10,37 +10,49 @@ enable_language(C)
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
 
-add_definitions(-DAWS_LC_RUST_INCLUDE_SSL)
+if (BUILD_LIBSSL)
+    add_definitions(-DAWS_LC_RUST_INCLUDE_SSL)
+endif()
 add_library(rust_wrapper STATIC rust_wrapper.c)
 target_include_directories(rust_wrapper PRIVATE include)
-target_link_libraries(rust_wrapper PUBLIC crypto ssl)
+
+if (BUILD_LIBSSL)
+    target_link_libraries(rust_wrapper PUBLIC crypto ssl)
+else()
+    target_link_libraries(rust_wrapper PUBLIC crypto)
+endif()
 
 set(FINAL_ARTIFACTS_DIRECTORY ${CMAKE_BINARY_DIR}/artifacts)
 
 # Places the compiled library files at the root of the binary directory so we can have a consistent
 # location to find the artifacts cross-platform.
-set_target_properties(rust_wrapper crypto ssl
+set_target_properties(rust_wrapper crypto
         PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
         LIBRARY_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY})
+
+if (BUILD_LIBSSL)
+    set_target_properties(ssl
+            PROPERTIES
+            ARCHIVE_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
+            LIBRARY_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY})
+endif()
 
 # Based on https://stackoverflow.com/a/7750816 as some generators, like MSVC, will try to prefix the output directory
 # which is not needed in our case.
 foreach (OUT_NAME ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${OUT_NAME} OUT_NAME)
-    set_target_properties(rust_wrapper crypto ssl
+    set_target_properties(rust_wrapper crypto
             PROPERTIES
             ARCHIVE_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
             LIBRARY_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY})
+    if (BUILD_LIBSSL)
+        set_target_properties(ssl
+                PROPERTIES
+                ARCHIVE_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
+                LIBRARY_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY})
+    endif()
 endforeach ()
-
-string(TOUPPER $<CONFIG> UPPER_CONFIG_NAME)
-
-set_property(TARGET rust_wrapper crypto ssl
-        PROPERTY ARCHIVE_OUTPUT_DIRECTORY_${UPPER_CONFIG_NAME})
-
-set_property(TARGET rust_wrapper crypto ssl
-        PROPERTY LIBRARY_OUTPUT_DIRECTORY_${UPPER_CONFIG_NAME})
 
 if (BORINGSSL_PREFIX)
     if (MSVC)
@@ -48,5 +60,8 @@ if (BORINGSSL_PREFIX)
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()
-    set_target_properties(rust_wrapper crypto ssl PROPERTIES PREFIX ${TARGET_PREFIX})
+    set_target_properties(rust_wrapper crypto PROPERTIES PREFIX ${TARGET_PREFIX})
+    if (BUILD_LIBSSL)
+        set_target_properties(ssl PROPERTIES PREFIX ${TARGET_PREFIX})
+    endif()
 endif ()

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -8,6 +8,13 @@ cmake_minimum_required(VERSION 3.0)
 project(AWS_LC_RUST NONE)
 enable_language(C)
 
+function(set_my_target_properties ...)
+    set_target_properties(rust_wrapper crypto PROPERTIES ${ARGV})
+    if (BUILD_LIBSSL)
+        set_target_properties(ssl PROPERTIES ${ARGV})
+    endif()
+endfunction()
+
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
 
 if (BUILD_LIBSSL)
@@ -15,43 +22,26 @@ if (BUILD_LIBSSL)
 endif()
 add_library(rust_wrapper STATIC rust_wrapper.c)
 target_include_directories(rust_wrapper PRIVATE include)
-
+target_link_libraries(rust_wrapper PUBLIC crypto)
 if (BUILD_LIBSSL)
-    target_link_libraries(rust_wrapper PUBLIC crypto ssl)
-else()
-    target_link_libraries(rust_wrapper PUBLIC crypto)
+    target_link_libraries(rust_wrapper PUBLIC ssl)
 endif()
 
 set(FINAL_ARTIFACTS_DIRECTORY ${CMAKE_BINARY_DIR}/artifacts)
 
 # Places the compiled library files at the root of the binary directory so we can have a consistent
 # location to find the artifacts cross-platform.
-set_target_properties(rust_wrapper crypto
-        PROPERTIES
+set_my_target_properties(
         ARCHIVE_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
         LIBRARY_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY})
-
-if (BUILD_LIBSSL)
-    set_target_properties(ssl
-            PROPERTIES
-            ARCHIVE_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
-            LIBRARY_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY})
-endif()
 
 # Based on https://stackoverflow.com/a/7750816 as some generators, like MSVC, will try to prefix the output directory
 # which is not needed in our case.
 foreach (OUT_NAME ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${OUT_NAME} OUT_NAME)
-    set_target_properties(rust_wrapper crypto
-            PROPERTIES
+    set_my_target_properties(
             ARCHIVE_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
             LIBRARY_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY})
-    if (BUILD_LIBSSL)
-        set_target_properties(ssl
-                PROPERTIES
-                ARCHIVE_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
-                LIBRARY_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY})
-    endif()
 endforeach ()
 
 if (BORINGSSL_PREFIX)
@@ -60,8 +50,5 @@ if (BORINGSSL_PREFIX)
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()
-    set_target_properties(rust_wrapper crypto PROPERTIES PREFIX ${TARGET_PREFIX})
-    if (BUILD_LIBSSL)
-        set_target_properties(ssl PROPERTIES PREFIX ${TARGET_PREFIX})
-    endif()
+    set_my_target_properties(PREFIX ${TARGET_PREFIX})
 endif ()

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -142,7 +142,11 @@ fn prepare_cmake_build(manifest_dir: &PathBuf, build_prefix: Option<&str>) -> cm
 
     // Build flags that minimize our crate size.
     cmake_cfg.define("BUILD_TESTING", "OFF");
-    cmake_cfg.define("BUILD_LIBSSL", "ON");
+    if cfg!(feature = "ssl") {
+        cmake_cfg.define("BUILD_LIBSSL", "ON");
+    } else {
+        cmake_cfg.define("BUILD_LIBSSL", "OFF");
+    }
     // Build flags that minimize our dependencies.
     cmake_cfg.define("DISABLE_PERL", "ON");
     cmake_cfg.define("DISABLE_GO", "ON");
@@ -159,7 +163,9 @@ fn prepare_cmake_build(manifest_dir: &PathBuf, build_prefix: Option<&str>) -> cm
 }
 
 fn build_rust_wrapper(manifest_dir: &PathBuf) -> PathBuf {
-    prepare_cmake_build(manifest_dir, Some(&prefix_string())).build()
+    prepare_cmake_build(manifest_dir, Some(&prefix_string()))
+        .configure_arg("--no-warn-unused-cli")
+        .build()
 }
 
 #[cfg(any(

--- a/scripts/generate/_crate_test_build.sh
+++ b/scripts/generate/_crate_test_build.sh
@@ -45,6 +45,7 @@ export GOPROXY=direct
 
 cargo clean --target-dir "${TEMP_TARGET_DIR}"
 cargo test --target-dir "${TEMP_TARGET_DIR}" --release
+cargo test --target-dir "${TEMP_TARGET_DIR}" --release --features ssl
 
 rm -rf "${TEMP_TARGET_DIR}" &>/dev/null || true
 

--- a/scripts/generate/_generate_bindings.sh
+++ b/scripts/generate/_generate_bindings.sh
@@ -42,7 +42,7 @@ cargo clean --target-dir "${TEMP_TARGET_DIR}"
 # Sets AWS_LC_RUST_INTERNAL_BINDGEN=1 which will cause the generation bindings for a specific platform. This feature
 # is only intended for internal use thus is not a cargo feature. Requires bindgen to be enabled. The internal_bindgen
 # config is enabled so that the final crates doesn't expect to find the dynamically generated bindings.rs
-env AWS_LC_RUST_INTERNAL_BINDGEN=1 cargo build --target-dir "${TEMP_TARGET_DIR}" --features bindgen
+env AWS_LC_RUST_INTERNAL_BINDGEN=1 cargo build --target-dir "${TEMP_TARGET_DIR}" --features bindgen,ssl
 cargo clean --target-dir "${TEMP_TARGET_DIR}"
 
 popd &>/dev/null # ${CRATE_DIR}


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
This change causes the build to only create `libssl` when the "ssl" feature is enabled. This improves overall build latency.

Before:
```
❯ time cargo build 
   Compiling cc v1.0.79
   Compiling libc v0.2.142
   Compiling paste v1.0.12
   Compiling dunce v1.0.4
   Compiling cmake v0.1.50
   Compiling aws-lc-sys v0.6.1 (/home/justsmth/repos/aws-lc-rs/aws-lc-sys)
    Finished dev [unoptimized + debuginfo] target(s) in 11.36s
cargo build  54.37s user 8.81s system 554% cpu 11.395 total
```

After:
```
❯ time cargo build
   Compiling cc v1.0.79
   Compiling libc v0.2.142
   Compiling paste v1.0.12
   Compiling dunce v1.0.4
   Compiling cmake v0.1.50
   Compiling aws-lc-sys v0.6.1 (/home/justsmth/repos/aws-lc-rs/aws-lc-sys)
    Finished dev [unoptimized + debuginfo] target(s) in 6.41s
cargo build  24.37s user 5.40s system 461% cpu 6.449 total
```

### Call-outs:
N/A

### Testing:
I've run the crate generation scripts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
