### PR TITLE
Only AES_encrypt is needed

### DIFF
--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -8,7 +8,7 @@
 //! See draft-ietf-quic-tls.
 
 use crate::aead::key_inner::KeyInner;
-use crate::cipher::aes::encrypt_block_aes_ecb;
+use crate::cipher::aes::encrypt_block_aes;
 use crate::cipher::chacha::encrypt_block_chacha20;
 use crate::cipher::{self, block, SymmetricCipherKey};
 use crate::hkdf::KeyType;
@@ -169,7 +169,7 @@ fn cipher_new_mask(key: &KeyInner, sample: Sample) -> Result<[u8; 5], error::Uns
 
     let encrypted_block = match cipher_key {
         SymmetricCipherKey::Aes128(.., aes_key) | SymmetricCipherKey::Aes256(.., aes_key) => {
-            encrypt_block_aes_ecb(aes_key, block)
+            encrypt_block_aes(aes_key, block)
         }
         SymmetricCipherKey::ChaCha20(key_bytes) => {
             let plaintext = block.as_ref();

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -115,10 +115,10 @@ impl SymmetricCipherKey {
 
     #[allow(dead_code)]
     #[inline]
-    pub fn encrypt_block(&self, block: Block) -> Result<Block, Unspecified> {
+    pub(crate) fn encrypt_block(&self, block: Block) -> Block {
         match self {
             SymmetricCipherKey::Aes128(.., aes_key) | SymmetricCipherKey::Aes256(.., aes_key) => {
-                Ok(encrypt_block_aes(aes_key, block))
+                encrypt_block_aes(aes_key, block)
             }
             SymmetricCipherKey::ChaCha20(..) => panic!("Unsupported algorithm!"),
         }
@@ -139,7 +139,7 @@ mod tests {
         let input_block: [u8; BLOCK_LEN] = <[u8; BLOCK_LEN]>::try_from(input).unwrap();
 
         let aes128 = SymmetricCipherKey::aes128(key.as_slice()).unwrap();
-        let result = aes128.encrypt_block(Block::from(&input_block)).unwrap();
+        let result = aes128.encrypt_block(Block::from(&input_block));
 
         assert_eq!(expected_result.as_slice(), result.as_ref());
     }
@@ -153,7 +153,7 @@ mod tests {
         let input_block: [u8; BLOCK_LEN] = <[u8; BLOCK_LEN]>::try_from(input).unwrap();
 
         let aes128 = SymmetricCipherKey::aes256(key.as_slice()).unwrap();
-        let result = aes128.encrypt_block(Block::from(&input_block)).unwrap();
+        let result = aes128.encrypt_block(Block::from(&input_block));
 
         assert_eq!(expected_result.as_slice(), result.as_ref());
     }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -7,7 +7,7 @@ pub(crate) mod aes;
 pub(crate) mod block;
 pub(crate) mod chacha;
 
-use crate::cipher::aes::{encrypt_block_aes_ecb, Aes128Key, Aes256Key};
+use crate::cipher::aes::{encrypt_block_aes, Aes128Key, Aes256Key};
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
 use crate::error::Unspecified;
@@ -24,7 +24,7 @@ pub(crate) enum SymmetricCipherKey {
 }
 
 unsafe impl Send for SymmetricCipherKey {}
-// The AES_KEY value is only used as a `*const AES_KEY` in calls to `AES_ecb_encrypt`.
+// The AES_KEY value is only used as a `*const AES_KEY` in calls to `AES_encrypt`.
 unsafe impl Sync for SymmetricCipherKey {}
 
 impl Drop for SymmetricCipherKey {
@@ -118,7 +118,7 @@ impl SymmetricCipherKey {
     pub fn encrypt_block(&self, block: Block) -> Result<Block, Unspecified> {
         match self {
             SymmetricCipherKey::Aes128(.., aes_key) | SymmetricCipherKey::Aes256(.., aes_key) => {
-                Ok(encrypt_block_aes_ecb(aes_key, block))
+                Ok(encrypt_block_aes(aes_key, block))
             }
             SymmetricCipherKey::ChaCha20(..) => panic!("Unsupported algorithm!"),
         }

--- a/aws-lc-rs/src/cipher/aes.rs
+++ b/aws-lc-rs/src/cipher/aes.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::cipher::block::{Block, BLOCK_LEN};
-use aws_lc::{AES_ecb_encrypt, AES_ENCRYPT, AES_KEY};
+use aws_lc::{AES_encrypt, AES_KEY};
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 use zeroize::Zeroize;
@@ -39,15 +39,14 @@ impl Drop for Aes256Key {
 }
 
 #[inline]
-pub(crate) fn encrypt_block_aes_ecb(aes_key: &AES_KEY, block: Block) -> Block {
+pub(crate) fn encrypt_block_aes(aes_key: &AES_KEY, block: Block) -> Block {
     unsafe {
         let mut cipher_text = MaybeUninit::<[u8; BLOCK_LEN]>::uninit();
         let plain_bytes = block.as_ref();
-        AES_ecb_encrypt(
+        AES_encrypt(
             plain_bytes.as_ptr(),
             cipher_text.as_mut_ptr().cast(),
             aes_key,
-            AES_ENCRYPT,
         );
 
         Block::from(&cipher_text.assume_init())


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* The [`quic::HeaderProtectionKey::new_mask`](https://docs.rs/aws-lc-rs/1.0.2/aws_lc_rs/aead/quic/struct.HeaderProtectionKey.html#method.new_mask) function has the need to encrypt a single block of data. Our logic was invoking `AES_ecb_encrypt` but because only a single block is being encrypted, it should call `AES_encrypt`.
* The performance on AES128 is slightly better (by fractions of a nanosecond) and about the same for AES256:
```
QUIC-Aes128Gcm-new-mask-sample-16-bytes/AWS-LC
                        time:   [5.3600 ns 5.3634 ns 5.3670 ns]
                        change: [-6.0478% -5.7802% -5.5706%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

QUIC-Aes256Gcm-new-mask-sample-16-bytes/AWS-LC
                        time:   [7.5755 ns 7.5818 ns 7.5903 ns]
                        change: [-1.0485% -0.8712% -0.6841%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
