### PR TITLE
Use recommended toolchain for api-diff CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         id: toolchain
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-01-04
           profile: minimal
           override: true
       - name: Install cargo-public-api


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Change toolchain used for api-diff to recommended.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
