### PR TITLE
Minor cipher refactoring; Add integ tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "aws-lc-sys",
     "aws-lc-fips-sys"
 ]
+resolver = "2"
 
 [profile.bench]
 lto = true

--- a/aws-lc-rs/benches/cipher_benchmark.rs
+++ b/aws-lc-rs/benches/cipher_benchmark.rs
@@ -1,5 +1,5 @@
 use aws_lc_rs::cipher::{
-    DecryptingKey, DecryptionContext, EncryptingKey, OperatingMode, PaddedBlockDecryptingKey,
+    CipherContext, DecryptingKey, EncryptingKey, OperatingMode, PaddedBlockDecryptingKey,
     PaddedBlockEncryptingKey, UnboundCipherKey, AES_128, AES_256,
 };
 use aws_lc_rs::{test, test_file};
@@ -31,8 +31,8 @@ macro_rules! benchmark_padded {
                 group.bench_function("AWS-LC", |b| {
                     b.iter(|| {
                         let key = UnboundCipherKey::new($awslc, &key_bytes).unwrap();
-                        let iv: DecryptionContext =
-                            DecryptionContext::Iv128(iv.as_slice().try_into().unwrap());
+                        let iv: CipherContext =
+                            CipherContext::Iv128(iv.as_slice().try_into().unwrap());
 
                         let encrypt_key = match $mode {
                             OperatingMode::CBC => {
@@ -78,8 +78,8 @@ macro_rules! benchmark_unpadded {
                 group.bench_function("AWS-LC", |b| {
                     b.iter(|| {
                         let key = UnboundCipherKey::new($awslc, &key_bytes).unwrap();
-                        let iv: DecryptionContext =
-                            DecryptionContext::Iv128(iv.as_slice().try_into().unwrap());
+                        let iv: CipherContext =
+                            CipherContext::Iv128(iv.as_slice().try_into().unwrap());
 
                         let encrypt_key = match $mode {
                             OperatingMode::CTR => EncryptingKey::less_safe_ctr(key, iv),

--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -463,6 +463,7 @@ pub struct UnboundKey {
     algorithm: &'static Algorithm,
 }
 
+#[allow(clippy::missing_fields_in_debug)]
 impl Debug for UnboundKey {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
         f.debug_struct("UnboundKey")

--- a/aws-lc-rs/src/aead/aes_gcm.rs
+++ b/aws-lc-rs/src/aead/aes_gcm.rs
@@ -5,7 +5,7 @@ use crate::aead::{Aad, Algorithm, AlgorithmID, Nonce, Tag, MAX_TAG_LEN};
 use std::mem::MaybeUninit;
 
 use crate::aead::key_inner::KeyInner;
-use crate::cipher::SymmetricCipherKey;
+use crate::cipher::key::SymmetricCipherKey;
 use crate::error::Unspecified;
 use aws_lc::EVP_AEAD_CTX_seal_scatter;
 use std::ptr::null;

--- a/aws-lc-rs/src/aead/chacha.rs
+++ b/aws-lc-rs/src/aead/chacha.rs
@@ -7,7 +7,7 @@
 use crate::aead::key_inner::KeyInner;
 use crate::aead::{Algorithm, AlgorithmID};
 use crate::cipher::chacha::KEY_LEN;
-use crate::cipher::SymmetricCipherKey;
+use crate::cipher::key::SymmetricCipherKey;
 
 use crate::error;
 

--- a/aws-lc-rs/src/aead/key_inner.rs
+++ b/aws-lc-rs/src/aead/key_inner.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aead::TAG_LEN;
-use crate::cipher::SymmetricCipherKey;
+use crate::cipher::key::SymmetricCipherKey;
 use crate::error;
 
 use aws_lc::{

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -10,7 +10,8 @@
 use crate::aead::key_inner::KeyInner;
 use crate::cipher::aes::encrypt_block_aes;
 use crate::cipher::chacha::encrypt_block_chacha20;
-use crate::cipher::{self, block, SymmetricCipherKey};
+use crate::cipher::key::SymmetricCipherKey;
+use crate::cipher::{block, key};
 use crate::hkdf::KeyType;
 use crate::{derive_debug_via_id, error, hkdf};
 use core::convert::TryFrom;
@@ -145,19 +146,19 @@ pub static CHACHA20: Algorithm = Algorithm {
 
 #[inline]
 fn aes_init_128(key: &[u8]) -> Result<KeyInner, error::Unspecified> {
-    let aes_key = cipher::SymmetricCipherKey::aes128(key)?;
+    let aes_key = key::SymmetricCipherKey::aes128(key)?;
     KeyInner::new(aes_key)
 }
 
 #[inline]
 fn aes_init_256(key: &[u8]) -> Result<KeyInner, error::Unspecified> {
-    let aes_key = cipher::SymmetricCipherKey::aes256(key)?;
+    let aes_key = key::SymmetricCipherKey::aes256(key)?;
     KeyInner::new(aes_key)
 }
 
 #[inline]
 fn chacha20_init(key: &[u8]) -> Result<KeyInner, error::Unspecified> {
-    let chacha20 = cipher::SymmetricCipherKey::chacha20(key)?;
+    let chacha20 = key::SymmetricCipherKey::chacha20(key)?;
     KeyInner::new(chacha20)
 }
 

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -180,17 +180,6 @@ impl<'a> TryFrom<&'a CipherContext> for &'a [u8] {
     }
 }
 
-impl<'a> TryFrom<&'a mut CipherContext> for &'a mut [u8] {
-    type Error = Unspecified;
-
-    fn try_from(value: &'a mut CipherContext) -> Result<Self, Unspecified> {
-        match value {
-            CipherContext::Iv128(iv) => Ok(iv.as_mut()),
-            CipherContext::None => Err(Unspecified),
-        }
-    }
-}
-
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 /// Cipher algorithm identifier.

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -1,0 +1,197 @@
+use crate::cipher::aes::{encrypt_block_aes, Aes128Key, Aes256Key};
+use crate::cipher::block::Block;
+use crate::cipher::chacha::ChaCha20Key;
+use crate::cipher::AES_128_KEY_LEN;
+use crate::error::Unspecified;
+use aws_lc::{AES_set_decrypt_key, AES_set_encrypt_key, AES_KEY};
+use core::ptr::copy_nonoverlapping;
+use std::mem::{size_of, transmute, MaybeUninit};
+use std::os::raw::c_uint;
+use std::ptr;
+use zeroize::Zeroize;
+
+pub(crate) enum SymmetricCipherKey {
+    Aes128 {
+        raw_key: Aes128Key,
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    Aes256 {
+        raw_key: Aes256Key,
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    ChaCha20 {
+        raw_key: ChaCha20Key,
+    },
+}
+
+unsafe impl Send for SymmetricCipherKey {}
+
+// The AES_KEY value is only used as a `*const AES_KEY` in calls to `AES_encrypt`.
+unsafe impl Sync for SymmetricCipherKey {}
+
+impl Drop for SymmetricCipherKey {
+    fn drop(&mut self) {
+        // Aes128Key, Aes256Key and ChaCha20Key implement Drop separately.
+        match self {
+            SymmetricCipherKey::Aes128 {
+                enc_key, dec_key, ..
+            }
+            | SymmetricCipherKey::Aes256 {
+                enc_key, dec_key, ..
+            } => unsafe {
+                #[allow(clippy::transmute_ptr_to_ptr)]
+                let enc_bytes: &mut [u8; size_of::<AES_KEY>()] = transmute(enc_key);
+                enc_bytes.zeroize();
+                #[allow(clippy::transmute_ptr_to_ptr)]
+                let dec_bytes: &mut [u8; size_of::<AES_KEY>()] = transmute(dec_key);
+                dec_bytes.zeroize();
+            },
+            SymmetricCipherKey::ChaCha20 { .. } => {}
+        }
+    }
+}
+
+impl SymmetricCipherKey {
+    pub(crate) fn aes128(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+        if key_bytes.len() != AES_128_KEY_LEN {
+            return Err(Unspecified);
+        }
+
+        unsafe {
+            let mut enc_key = MaybeUninit::<AES_KEY>::uninit();
+            #[allow(clippy::cast_possible_truncation)]
+            if 0 != AES_set_encrypt_key(
+                key_bytes.as_ptr(),
+                (key_bytes.len() * 8) as c_uint,
+                enc_key.as_mut_ptr(),
+            ) {
+                return Err(Unspecified);
+            }
+            let enc_key = enc_key.assume_init();
+
+            let mut dec_key = MaybeUninit::<AES_KEY>::uninit();
+            #[allow(clippy::cast_possible_truncation)]
+            if 0 != AES_set_decrypt_key(
+                key_bytes.as_ptr(),
+                (key_bytes.len() * 8) as c_uint,
+                dec_key.as_mut_ptr(),
+            ) {
+                return Err(Unspecified);
+            }
+            let dec_key = dec_key.assume_init();
+
+            let mut kb = MaybeUninit::<[u8; 16]>::uninit();
+            ptr::copy_nonoverlapping(key_bytes.as_ptr(), kb.as_mut_ptr().cast(), 16);
+            Ok(SymmetricCipherKey::Aes128 {
+                raw_key: Aes128Key(kb.assume_init()),
+                enc_key,
+                dec_key,
+            })
+        }
+    }
+
+    pub(crate) fn aes256(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+        if key_bytes.len() != 32 {
+            return Err(Unspecified);
+        }
+        unsafe {
+            let mut enc_key = MaybeUninit::<AES_KEY>::uninit();
+            #[allow(clippy::cast_possible_truncation)]
+            if 0 != AES_set_encrypt_key(
+                key_bytes.as_ptr(),
+                (key_bytes.len() * 8) as c_uint,
+                enc_key.as_mut_ptr(),
+            ) {
+                return Err(Unspecified);
+            }
+            let enc_key = enc_key.assume_init();
+
+            let mut dec_key = MaybeUninit::<AES_KEY>::uninit();
+            #[allow(clippy::cast_possible_truncation)]
+            if 0 != AES_set_decrypt_key(
+                key_bytes.as_ptr(),
+                (key_bytes.len() * 8) as c_uint,
+                dec_key.as_mut_ptr(),
+            ) {
+                return Err(Unspecified);
+            }
+            let dec_key = dec_key.assume_init();
+
+            let mut kb = MaybeUninit::<[u8; 32]>::uninit();
+            copy_nonoverlapping(key_bytes.as_ptr(), kb.as_mut_ptr().cast(), 32);
+            Ok(SymmetricCipherKey::Aes256 {
+                raw_key: Aes256Key(kb.assume_init()),
+                enc_key,
+                dec_key,
+            })
+        }
+    }
+
+    pub(crate) fn chacha20(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+        if key_bytes.len() != 32 {
+            return Err(Unspecified);
+        }
+        let mut kb = MaybeUninit::<[u8; 32]>::uninit();
+        unsafe {
+            copy_nonoverlapping(key_bytes.as_ptr(), kb.as_mut_ptr().cast(), 32);
+            Ok(SymmetricCipherKey::ChaCha20 {
+                raw_key: ChaCha20Key(kb.assume_init()),
+            })
+        }
+    }
+
+    #[inline]
+    pub(crate) fn key_bytes(&self) -> &[u8] {
+        match self {
+            SymmetricCipherKey::Aes128 { raw_key, .. } => &raw_key.0,
+            SymmetricCipherKey::Aes256 { raw_key, .. } => &raw_key.0,
+            SymmetricCipherKey::ChaCha20 { raw_key, .. } => &raw_key.0,
+        }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn encrypt_block(&self, block: Block) -> Block {
+        match self {
+            SymmetricCipherKey::Aes128 { enc_key, .. }
+            | SymmetricCipherKey::Aes256 { enc_key, .. } => encrypt_block_aes(enc_key, block),
+            SymmetricCipherKey::ChaCha20 { .. } => panic!("Unsupported algorithm!"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cipher::block::{Block, BLOCK_LEN};
+    use crate::cipher::key::SymmetricCipherKey;
+    use crate::test::from_hex;
+
+    #[test]
+    fn test_encrypt_block_aes_128() {
+        let key = from_hex("000102030405060708090a0b0c0d0e0f").unwrap();
+        let input = from_hex("00112233445566778899aabbccddeeff").unwrap();
+        let expected_result = from_hex("69c4e0d86a7b0430d8cdb78070b4c55a").unwrap();
+        let input_block: [u8; BLOCK_LEN] = <[u8; BLOCK_LEN]>::try_from(input).unwrap();
+
+        let aes128 = SymmetricCipherKey::aes128(key.as_slice()).unwrap();
+        let result = aes128.encrypt_block(Block::from(&input_block));
+
+        assert_eq!(expected_result.as_slice(), result.as_ref());
+    }
+
+    #[test]
+    fn test_encrypt_block_aes_256() {
+        let key =
+            from_hex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f").unwrap();
+        let input = from_hex("00112233445566778899aabbccddeeff").unwrap();
+        let expected_result = from_hex("8ea2b7ca516745bfeafc49904b496089").unwrap();
+        let input_block: [u8; BLOCK_LEN] = <[u8; BLOCK_LEN]>::try_from(input).unwrap();
+
+        let aes128 = SymmetricCipherKey::aes256(key.as_slice()).unwrap();
+        let result = aes128.encrypt_block(Block::from(&input_block));
+
+        assert_eq!(expected_result.as_slice(), result.as_ref());
+    }
+}

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -92,6 +92,7 @@ pub struct Salt {
     key_len: usize,
 }
 
+#[allow(clippy::missing_fields_in_debug)]
 impl fmt::Debug for Salt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("hkdf::Salt")
@@ -207,6 +208,7 @@ pub struct Prk {
     key_len: usize,
 }
 
+#[allow(clippy::missing_fields_in_debug)]
 impl fmt::Debug for Prk {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("hkdf::Prk")

--- a/aws-lc-rs/src/hmac.rs
+++ b/aws-lc-rs/src/hmac.rs
@@ -206,6 +206,7 @@ unsafe impl Send for Key {}
 // All uses of *mut HMAC_CTX require the creation of a Context, which will clone the Key.
 unsafe impl Sync for Key {}
 
+#[allow(clippy::missing_fields_in_debug)]
 impl core::fmt::Debug for Key {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
         f.debug_struct("Key")

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -1,0 +1,319 @@
+use aws_lc_rs::cipher::{
+    CipherContext, DecryptingKey, EncryptingKey, OperatingMode, PaddedBlockDecryptingKey,
+    PaddedBlockEncryptingKey, PaddingStrategy, UnboundCipherKey, AES_128, AES_256,
+};
+use aws_lc_rs::iv::FixedLength;
+use aws_lc_rs::test::from_hex;
+
+macro_rules! padded_cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, $padding:expr, $constructor:ident, $key:literal, $iv: literal, $plaintext:literal, $ciphertext:literal) => { paste::item! {
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            let iv = from_hex($iv).unwrap();
+            let fixed_iv = FixedLength::try_from(iv.as_slice()).unwrap();
+            let context = CipherContext::Iv128(fixed_iv);
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+
+            let encrypting_key =
+                PaddedBlockEncryptingKey::[<less_safe_ $constructor>](unbound_key, context).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($padding, encrypting_key.padding());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key.encrypt(&mut in_out).unwrap();
+            assert_eq!(expected_ciphertext.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key =
+                PaddedBlockDecryptingKey::$constructor(unbound_key2, context).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($padding, decrypting_key.padding());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+    }};
+}
+
+macro_rules! cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv: literal, $plaintext:literal, $ciphertext:literal) => {
+        paste::item! {
+            #[test]
+            fn $name() {
+                let key = from_hex($key).unwrap();
+                let input = from_hex($plaintext).unwrap();
+                let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+                let iv = from_hex($iv).unwrap();
+                let fixed_iv = FixedLength::try_from(iv.as_slice()).unwrap();
+                let context = CipherContext::Iv128(fixed_iv);
+
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+
+                let encrypting_key =
+                    EncryptingKey::[<less_safe_ $constructor>](unbound_key, context).unwrap();
+                assert_eq!($mode, encrypting_key.mode());
+                assert_eq!($alg, encrypting_key.algorithm());
+                let mut in_out = input.clone();
+                let context = encrypting_key.encrypt(in_out.as_mut_slice()).unwrap();
+                assert_eq!(expected_ciphertext.as_slice(), in_out);
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    DecryptingKey::$constructor(unbound_key2, context).unwrap();
+                assert_eq!($mode, decrypting_key.mode());
+                assert_eq!($alg, decrypting_key.algorithm());
+                let plaintext = decrypting_key.decrypt(&mut in_out).unwrap();
+                assert_eq!(input.as_slice(), plaintext);
+            }
+        }
+    };
+}
+
+macro_rules! padded_cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $padding:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
+        paste::item! {
+            #[test]
+            fn $name() {
+                let key = from_hex($key).unwrap();
+                let input = from_hex($plaintext).unwrap();
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+
+                let encrypting_key = PaddedBlockEncryptingKey::$constructor(unbound_key).unwrap();
+                assert_eq!($mode, encrypting_key.mode());
+                assert_eq!($padding, encrypting_key.padding());
+                assert_eq!($alg, encrypting_key.algorithm());
+                let mut in_out = input.clone();
+                let context = encrypting_key.encrypt(&mut in_out).unwrap();
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    PaddedBlockDecryptingKey::$constructor(unbound_key2, context).unwrap();
+                assert_eq!($mode, decrypting_key.mode());
+                assert_eq!($padding, decrypting_key.padding());
+                assert_eq!($alg, decrypting_key.algorithm());
+                let plaintext = decrypting_key.decrypt(&mut in_out).unwrap();
+                assert_eq!(input.as_slice(), plaintext);
+            }
+        }
+    };
+}
+
+macro_rules! cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+
+            let encrypting_key = EncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key.encrypt(in_out.as_mut_slice()).unwrap();
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = DecryptingKey::$constructor(unbound_key2, context).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+    };
+}
+
+padded_cipher_kat!(
+    test_kat_aes_128_cbc_16_bytes,
+    &AES_128,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "000102030405060708090a0b0c0d0e0f",
+    "00000000000000000000000000000000",
+    "00112233445566778899aabbccddeeff",
+    "69c4e0d86a7b0430d8cdb78070b4c55a9e978e6d16b086570ef794ef97984232"
+);
+
+padded_cipher_kat!(
+    test_kat_aes_256_cbc_15_bytes,
+    &AES_256,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    "00000000000000000000000000000000",
+    "00112233445566778899aabbccddee",
+    "2ddfb635a651a43f582997966840ca0c"
+);
+
+cipher_kat!(
+    test_kat_aes_128_ctr_16_bytes,
+    &AES_128,
+    OperatingMode::CTR,
+    ctr,
+    "000102030405060708090a0b0c0d0e0f",
+    "00000000000000000000000000000000",
+    "00112233445566778899aabbccddeeff",
+    "c6b01904c3da3df5e7d62bd96d153686"
+);
+
+cipher_kat!(
+    test_kat_aes_256_ctr_15_bytes,
+    &AES_256,
+    OperatingMode::CTR,
+    ctr,
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    "00000000000000000000000000000000",
+    "00112233445566778899aabbccddee",
+    "f28122856e1cf9a7216a30d111f399"
+);
+
+cipher_kat!(
+    test_kat_aes_128_ctr_15_bytes,
+    &AES_128,
+    OperatingMode::CTR,
+    ctr,
+    "244828580821c1652582c76e34d299f5",
+    "093145d5af233f46072a5eb5adc11aa1",
+    "3ee38cec171e6cf466bf0df98aa0e1",
+    "bd7d928f60e3422d96b3f8cd614eb2"
+);
+
+cipher_kat!(
+    test_kat_256_ctr_15_bytes,
+    &AES_256,
+    OperatingMode::CTR,
+    ctr,
+    "0857db8240ea459bdf660b4cced66d1f2d3734ff2de7b81e92740e65e7cc6a1d",
+    "f028ecb053f801102d11fccc9d303a27",
+    "eca7285d19f3c20e295378460e8729",
+    "b5098e5e788de6ac2f2098eb2fc6f8"
+);
+
+padded_cipher_kat!(
+    test_kat_aes_128_cbc_15_bytes,
+    &AES_128,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "053304bb3899e1d99db9d29343ea782d",
+    "b5313560244a4822c46c2a0c9d0cf7fd",
+    "a3e4c990356c01f320043c3d8d6f43",
+    "ad96993f248bd6a29760ec7ccda95ee1"
+);
+
+padded_cipher_kat!(
+    test_kat_128_cbc_16_bytes,
+    &AES_128,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "95af71f1c63e4a1d0b0b1a27fb978283",
+    "89e40797dca70197ff87d3dbb0ef2802",
+    "aece7b5e3c3df1ffc9802d2dfe296dc7",
+    "301b5dab49fb11e919d0d39970d06739301919743304f23f3cbc67d28564b25b"
+);
+
+padded_cipher_kat!(
+    test_kat_aes_256_cbc_16_bytes,
+    &AES_256,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "d4a8206dcae01242f9db79a4ecfe277d0f7bb8ccbafd8f9809adb39f35aa9b41",
+    "24f6076548fb9d93c8f7ed9f6e661ef9",
+    "a39c1fdf77ea3e1f18178c0ec237c70a",
+    "f1af484830a149ee0387b854d65fe87ca0e62efc1c8e6909d4b9ab8666470453"
+);
+
+padded_cipher_rt!(
+    test_rt_aes_128_cbc_16_bytes,
+    &AES_128,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "000102030405060708090a0b0c0d0e0f",
+    "00112233445566778899aabbccddeeff"
+);
+
+padded_cipher_rt!(
+    test_rt_aes_256_cbc_15_bytes,
+    &AES_256,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    "00112233445566778899aabbccddee"
+);
+
+cipher_rt!(
+    test_rt_aes_128_ctr_16_bytes,
+    &AES_128,
+    OperatingMode::CTR,
+    ctr,
+    "000102030405060708090a0b0c0d0e0f",
+    "00112233445566778899aabbccddeeff"
+);
+
+cipher_rt!(
+    test_rt_aes_256_ctr_15_bytes,
+    &AES_256,
+    OperatingMode::CTR,
+    ctr,
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    "00112233445566778899aabbccddee"
+);
+
+cipher_rt!(
+    test_rt_aes_128_ctr_15_bytes,
+    &AES_128,
+    OperatingMode::CTR,
+    ctr,
+    "244828580821c1652582c76e34d299f5",
+    "3ee38cec171e6cf466bf0df98aa0e1"
+);
+
+cipher_rt!(
+    test_rt_256_ctr_15_bytes,
+    &AES_256,
+    OperatingMode::CTR,
+    ctr,
+    "0857db8240ea459bdf660b4cced66d1f2d3734ff2de7b81e92740e65e7cc6a1d",
+    "eca7285d19f3c20e295378460e8729"
+);
+
+padded_cipher_rt!(
+    test_rt_aes_128_cbc_15_bytes,
+    &AES_128,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "053304bb3899e1d99db9d29343ea782d",
+    "a3e4c990356c01f320043c3d8d6f43"
+);
+
+padded_cipher_rt!(
+    test_rt_128_cbc_16_bytes,
+    &AES_128,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "95af71f1c63e4a1d0b0b1a27fb978283",
+    "aece7b5e3c3df1ffc9802d2dfe296dc7"
+);
+
+padded_cipher_rt!(
+    test_rt_aes_256_cbc_16_bytes,
+    &AES_256,
+    OperatingMode::CBC,
+    PaddingStrategy::PKCS7,
+    cbc_pkcs7,
+    "d4a8206dcae01242f9db79a4ecfe277d0f7bb8ccbafd8f9809adb39f35aa9b41",
+    "a39c1fdf77ea3e1f18178c0ec237c70a"
+);


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Renamed `DecryptionContext` to `CipherContext`
* Moved `SymmetricCipherKey` to a `key` sub-module.
* `impl AsRef<[u8]> for CipherContext`
* `#[derive(Debug, PartialEq, Eq, Clone, Copy)]` on simple enums.
* Add integ tests.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
