### PR TITLE
Remove TryFrom conversions for padding to unpadded

### DIFF
--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -83,7 +83,7 @@ use zeroize::Zeroize;
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PaddingStrategy {
-    /// PKCS#7 Padding.
+    /// PKCS#7 Padding. ([See RFC 5652](https://datatracker.ietf.org/doc/html/rfc5652#section-6.3))
     PKCS7,
 }
 
@@ -368,15 +368,11 @@ impl PaddedBlockEncryptingKey {
     {
         self.padding
             .add_padding(self.algorithm().block_len(), in_out)?;
-        TryInto::<EncryptingKey>::try_into(self)?.encrypt(in_out.as_mut())
+        self.into_encrypting_key()?.encrypt(in_out.as_mut())
     }
-}
 
-impl TryFrom<PaddedBlockEncryptingKey> for EncryptingKey {
-    type Error = Unspecified;
-
-    fn try_from(value: PaddedBlockEncryptingKey) -> Result<Self, Self::Error> {
-        EncryptingKey::new(value.key, value.mode, Some(value.context))
+    fn into_encrypting_key(self) -> Result<EncryptingKey, Unspecified> {
+        EncryptingKey::new(self.key, self.mode, Some(self.context))
     }
 }
 
@@ -447,9 +443,13 @@ impl PaddedBlockDecryptingKey {
     pub fn decrypt(self, in_out: &mut [u8]) -> Result<&mut [u8], Unspecified> {
         let block_len = self.algorithm().block_len();
         let padding = self.padding;
-        let mut in_out = TryInto::<DecryptingKey>::try_into(self)?.decrypt(in_out)?;
+        let mut in_out = self.into_decrypting_key()?.decrypt(in_out)?;
         in_out = padding.remove_padding(block_len, in_out)?;
         Ok(in_out)
+    }
+
+    fn into_decrypting_key(self) -> Result<DecryptingKey, Unspecified> {
+        DecryptingKey::new(self.key, self.mode, self.mode_input)
     }
 }
 
@@ -626,14 +626,6 @@ impl DecryptingKey {
                 }
             },
         }
-    }
-}
-
-impl TryFrom<PaddedBlockDecryptingKey> for DecryptingKey {
-    type Error = Unspecified;
-
-    fn try_from(value: PaddedBlockDecryptingKey) -> Result<Self, Self::Error> {
-        DecryptingKey::new(value.key, value.mode, value.mode_input)
     }
 }
 


### PR DESCRIPTION
Removes:
* `impl TryFrom<PaddedBlockEncryptingKey> for EncryptingKey`
* `impl TryFrom<PaddedBlockDecryptingKey> for DecryptingKey`

These could have been used by a user to bypass our (intentional) limitation of not allowing a user to use CBC mode without padding.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
