### PR TITLE
Support KKDF; Minor doc improvements

### DIFF
--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -83,7 +83,7 @@
 //!
 //! #### - bindgen ####
 //! Causes `aws-lc-sys` or `aws-lc-fips-sys` to generates fresh bindings for AWS-LC instead of using
-//! the pre-generated bindings. This feature require `libclang` to be installed. See the
+//! the pre-generated bindings. This feature requires `libclang` to be installed. See the
 //! [requirements](https://rust-lang.github.io/rust-bindgen/requirements.html)
 //! for [rust-bindgen](https://github.com/rust-lang/rust-bindgen)
 //!

--- a/aws-lc-rs/tests/hkdf_test.rs
+++ b/aws-lc-rs/tests/hkdf_test.rs
@@ -3,7 +3,7 @@
 // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use aws_lc_rs::{aead, digest, error, hkdf, hmac, test, test_file};
+use aws_lc_rs::{aead, cipher, digest, error, hkdf, hmac, test, test_file};
 
 #[test]
 fn hkdf_tests() {
@@ -121,6 +121,11 @@ fn hkdf_key_types() {
         ] {
             let okm = prk.expand(&[b"info"], aead_alg).unwrap();
             let _aead_prk_key = aead::UnboundKey::from(okm);
+        }
+
+        for cipher_alg in [&cipher::AES_256, &cipher::AES_128] {
+            let okm = prk.expand(&[b"info"], cipher_alg).unwrap();
+            let _aead_prk_key = cipher::UnboundCipherKey::from(okm);
         }
     }
 }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Support HKDF for generation of UnboundCipherKey
* Make `AES_128` and `AES_256` "static".
* `impl Debug for UnboundCipherKey`
* Minor documentation tweaks.

### Call-outs:
N/A

### Testing:
Updated tests to cover HKDF for `UnboundCipherKey` and its Debug impl.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
