### PR TITLE
Run openssl cipher-benchmarks with openssl-benchmarks feature

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -28,6 +28,7 @@ default = ["aws-lc-sys", "alloc", "ring-io", "ring-sig-verify"]
 ring-io = ["dep:untrusted"]
 ring-sig-verify = ["dep:untrusted"]
 ring-benchmarks = []
+openssl-benchmarks = []
 bindgen = ["aws-lc-sys?/bindgen", "aws-lc-fips-sys?/bindgen"]
 asan = ["aws-lc-sys?/asan", "aws-lc-fips-sys?/asan"]
 

--- a/aws-lc-rs/benches/cipher_benchmark.rs
+++ b/aws-lc-rs/benches/cipher_benchmark.rs
@@ -4,8 +4,10 @@ use aws_lc_rs::cipher::{
 };
 use aws_lc_rs::{test, test_file};
 use criterion::{criterion_group, criterion_main, Criterion};
+#[cfg(feature = "openssl-benchmarks")]
 use openssl::symm::Cipher;
 
+#[cfg(feature = "openssl-benchmarks")]
 macro_rules! openssl_bench {
     ($group:ident, $openssl: expr, $key:ident, $iv:ident, $data:ident) => {
         $group.bench_function("OpenSSL", |b| {
@@ -15,6 +17,13 @@ macro_rules! openssl_bench {
                 let _ = decrypt($openssl, &$key, Some(&$iv), data.as_ref()).unwrap();
             })
         });
+    };
+}
+
+#[cfg(not(feature = "openssl-benchmarks"))]
+macro_rules! openssl_bench {
+    ($group:ident, $openssl: expr, $key:ident, $iv:ident, $data:ident) => {
+        // NO-OP
     };
 }
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Only run OpenSSL benchmarks when feature "openssl-benchmarks" is enabled.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
